### PR TITLE
docs: fix typo in Read People book title

### DIFF
--- a/app/docs/blueprint/soft-skills.md
+++ b/app/docs/blueprint/soft-skills.md
@@ -55,7 +55,7 @@ Below are some resources to help you dive deeper into building those skills that
 | How to Win Friends and Influence People | Dale Carnegie         | https://amzn.to/3DIitxx |
 | 7 Habits of Highly Effective People     | Stephen R. Covey      | https://amzn.to/4abqB5P |
 | Active Listening Techniques             | Nixaly Leonardo, LCSW | https://amzn.to/422bee6 |
-| Read Peoplie                            | Rita Carter           | https://amzn.to/3C3cumw |
+| Read People                           | Rita Carter           | https://amzn.to/3C3cumw |
 | The 3rd Alternative                     | Steven Covey          | https://amzn.to/4ijLgb1 |
 | Exactly What to Say                     | Phil Jones            | https://amzn.to/3EGcrhr |
 | How to Talk So Little Kids Will Listen  | Joanna Faber          | https://amzn.to/4gIOX8I |


### PR DESCRIPTION
Fixed a small typo in the Read People book title.

No functional changes and documentation-only correction.