### PR TITLE
ci(workflow): skip SonarQube on PRs without secret access and add workflow_dispatch

### DIFF
--- a/.github/workflows/sonarqube.yml
+++ b/.github/workflows/sonarqube.yml
@@ -5,22 +5,35 @@ on:
     branches:
       - main
     paths-ignore:
-      - 'docs/**'
-      - '**/*.md'
+      - "docs/**"
+      - "**/*.md"
   pull_request:
     branches:
       - main
     types: [opened, synchronize, reopened]
     paths-ignore:
-      - 'docs/**'
-      - '**/*.md'
+      - "docs/**"
+      - "**/*.md"
+  workflow_dispatch:
+    inputs:
+      ref:
+        description: "Branch, tag, or commit SHA to scan (defaults to the dispatching ref)"
+        required: false
+        type: string
 
 concurrency:
-  group: sonarqube-${{ github.ref }}
+  group: sonarqube-${{ inputs.ref || github.ref }}
   cancel-in-progress: true
 
 jobs:
   sonarqube:
+    # Skip PRs from forks: repository secrets are unavailable to fork-triggered
+    # pull_request runs, which would cause the scan to fail without SONAR_TOKEN
+    # and SONAR_HOST_URL. Same-repo PRs and pushes proceed normally; maintainers
+    # can manually scan fork commits via workflow_dispatch with the `ref` input.
+    if: >-
+      github.event_name != 'pull_request' ||
+      github.event.pull_request.head.repo.full_name == github.repository
     runs-on: ubuntu-latest
     permissions:
       contents: read
@@ -29,6 +42,7 @@ jobs:
       - uses: actions/checkout@v6
         with:
           fetch-depth: 0
+          ref: ${{ inputs.ref || github.ref }}
 
       - name: Set up JDK 17
         uses: actions/setup-java@v4

--- a/.github/workflows/sonarqube.yml
+++ b/.github/workflows/sonarqube.yml
@@ -27,13 +27,18 @@ concurrency:
 
 jobs:
   sonarqube:
-    # Skip PRs from forks: repository secrets are unavailable to fork-triggered
-    # pull_request runs, which would cause the scan to fail without SONAR_TOKEN
-    # and SONAR_HOST_URL. Same-repo PRs and pushes proceed normally; maintainers
-    # can manually scan fork commits via workflow_dispatch with the `ref` input.
+    # Skip PRs that cannot access repository secrets, which would cause the
+    # scan to fail without SONAR_TOKEN and SONAR_HOST_URL:
+    #   - Fork PRs: GitHub withholds secrets from pull_request runs whose head
+    #     repository is a fork.
+    #   - Dependabot PRs: by default secrets.* is not exposed to dependabot-
+    #     triggered runs (Dependabot has a separate secret store).
+    # Pushes to main and same-repo PRs proceed normally; maintainers can
+    # manually scan any ref via workflow_dispatch with the `ref` input.
     if: >-
       github.event_name != 'pull_request' ||
-      github.event.pull_request.head.repo.full_name == github.repository
+      (github.event.pull_request.head.repo.full_name == github.repository &&
+       github.actor != 'dependabot[bot]')
     runs-on: ubuntu-latest
     permissions:
       contents: read


### PR DESCRIPTION
## Problem

The SonarQube workflow merged in #126 fails on any `pull_request` run that cannot access repository secrets, producing:

```
Warning: Running this GitHub Action without SONAR_TOKEN
ERROR Failed to query server version: Expected URL scheme 'http' or 'https' but no scheme was found for /api/v...
```

Two categories of PR hit this:

1. **PRs from forks** — GitHub deliberately withholds `secrets.*` from `pull_request` runs whose head repository is a fork (security: prevents secret exfiltration via malicious workflow edits).
2. **Dependabot PRs** — since Sept 2021, GitHub does not expose `secrets.*` to workflows triggered by Dependabot, even on same-repo branches. Dependabot has a separate secret store at *Settings → Secrets and variables → Dependabot*. PRs #127 and #128 are currently failing for this reason.

## Changes

`.github/workflows/sonarqube.yml`:

- Add a job-level `if:` guard so the job is **skipped** (not failed) when secrets are guaranteed-unavailable: PRs from forks **and** PRs where the actor is `dependabot[bot]`.
- Add a `workflow_dispatch` trigger with an optional `ref` input (branch, tag, or commit SHA). The input is wired through `actions/checkout` and the concurrency group. This gives maintainers a controlled way to scan a fork's commit or a Dependabot branch on demand: the workflow YAML executed is the one on `main`, not whatever a fork or Dependabot proposes.
- Same-repo, non-Dependabot PRs and pushes to `main` continue to run unchanged.

No changes to `sonar-project.properties` or `docs/SONARQUBE.md`.

## Why `workflow_dispatch` instead of `pull_request_target`

`pull_request_target` would also expose secrets to fork PRs, but it has a well-known footgun: if the workflow checks out `${{ github.event.pull_request.head.sha }}`, malicious workflow YAML or scripts in the PR can run with access to those secrets. `workflow_dispatch` avoids this entirely — only users with write access to the upstream repo can trigger it, and the workflow YAML executed is always the version on `main`.

## Verification

- Fork-PR run on `feat/sonarqube-skip-untrusted-prs` (this PR) should report the SonarQube job as **skipped**, not failed.
- Open Dependabot PRs (#127, #128) will need to be rebased / re-run after merge to pick up the new guard; the SonarQube job on them will then also skip.
- Post-merge `push` to `main` will run the scan normally (assuming `SONAR_TOKEN` and `SONAR_HOST_URL` are configured on the upstream repo).

## Optional follow-up (not in this PR)

If you want Dependabot's bumps to also be scanned before merge, mirror the two secrets into *Settings → Secrets and variables → Dependabot* and change the guard to drop the `dependabot[bot]` exclusion.

---
Pull Request opened by [Augment Code](https://www.augmentcode.com/) with guidance from the PR author