### PR TITLE
fix(security): bump urllib3 from 2.6.3 to 2.7.0

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -44,7 +44,7 @@ dependencies = [
     "s3transfer==0.16.0",
     "six==1.17.0",
     "sortedcontainers==2.4.0",
-    "urllib3==2.6.3",
+    "urllib3==2.7.0",
     "werkzeug==3.1.8",
     "xmltodict==1.0.4",
 ]

--- a/uv.lock
+++ b/uv.lock
@@ -428,7 +428,7 @@ requires-dist = [
     { name = "invoke", specifier = ">=2.2.1" },
     { name = "jinja2", specifier = "==3.1.6" },
     { name = "jmespath", specifier = "==1.1.0" },
-    { name = "markdown", specifier = ">=3.10.2" },
+    { name = "markdown", specifier = "==3.7" },
     { name = "markupsafe", specifier = "==3.0.3" },
     { name = "moto", specifier = "==5.1.22" },
     { name = "mypy-extensions", specifier = "==1.1.0" },
@@ -451,7 +451,7 @@ requires-dist = [
     { name = "s3transfer", specifier = "==0.16.0" },
     { name = "six", specifier = "==1.17.0" },
     { name = "sortedcontainers", specifier = "==2.4.0" },
-    { name = "urllib3", specifier = "==2.6.3" },
+    { name = "urllib3", specifier = "==2.7.0" },
     { name = "werkzeug", specifier = "==3.1.8" },
     { name = "xmltodict", specifier = "==1.0.4" },
 ]
@@ -539,11 +539,11 @@ wheels = [
 
 [[package]]
 name = "markdown"
-version = "3.10.2"
+version = "3.7"
 source = { registry = "https://pypi.org/simple" }
-sdist = { url = "https://files.pythonhosted.org/packages/2b/f4/69fa6ed85ae003c2378ffa8f6d2e3234662abd02c10d216c0ba96081a238/markdown-3.10.2.tar.gz", hash = "sha256:994d51325d25ad8aa7ce4ebaec003febcce822c3f8c911e3b17c52f7f589f950", size = 368805, upload-time = "2026-02-09T14:57:26.942Z" }
+sdist = { url = "https://files.pythonhosted.org/packages/54/28/3af612670f82f4c056911fbbbb42760255801b3068c48de792d354ff4472/markdown-3.7.tar.gz", hash = "sha256:2ae2471477cfd02dbbf038d5d9bc226d40def84b4fe2986e49b59b6b472bbed2", size = 357086, upload-time = "2024-08-16T15:55:17.812Z" }
 wheels = [
-    { url = "https://files.pythonhosted.org/packages/de/1f/77fa3081e4f66ca3576c896ae5d31c3002ac6607f9747d2e3aa49227e464/markdown-3.10.2-py3-none-any.whl", hash = "sha256:e91464b71ae3ee7afd3017d9f358ef0baf158fd9a298db92f1d4761133824c36", size = 108180, upload-time = "2026-02-09T14:57:25.787Z" },
+    { url = "https://files.pythonhosted.org/packages/3f/08/83871f3c50fc983b88547c196d11cf8c3340e37c32d2e9d6152abe2c61f7/Markdown-3.7-py3-none-any.whl", hash = "sha256:7eb6df5690b81a1d7942992c97fad2938e956e79df20cbc6186e9c3a77b1c803", size = 106349, upload-time = "2024-08-16T15:55:16.176Z" },
 ]
 
 [[package]]
@@ -900,11 +900,11 @@ wheels = [
 
 [[package]]
 name = "urllib3"
-version = "2.6.3"
+version = "2.7.0"
 source = { registry = "https://pypi.org/simple" }
-sdist = { url = "https://files.pythonhosted.org/packages/c7/24/5f1b3bdffd70275f6661c76461e25f024d5a38a46f04aaca912426a2b1d3/urllib3-2.6.3.tar.gz", hash = "sha256:1b62b6884944a57dbe321509ab94fd4d3b307075e0c2eae991ac71ee15ad38ed", size = 435556, upload-time = "2026-01-07T16:24:43.925Z" }
+sdist = { url = "https://files.pythonhosted.org/packages/53/0c/06f8b233b8fd13b9e5ee11424ef85419ba0d8ba0b3138bf360be2ff56953/urllib3-2.7.0.tar.gz", hash = "sha256:231e0ec3b63ceb14667c67be60f2f2c40a518cb38b03af60abc813da26505f4c", size = 433602, upload-time = "2026-05-07T16:13:18.596Z" }
 wheels = [
-    { url = "https://files.pythonhosted.org/packages/39/08/aaaad47bc4e9dc8c725e68f9d04865dbcb2052843ff09c97b08904852d84/urllib3-2.6.3-py3-none-any.whl", hash = "sha256:bf272323e553dfb2e87d9bfd225ca7b0f467b919d7bbd355436d3fd37cb0acd4", size = 131584, upload-time = "2026-01-07T16:24:42.685Z" },
+    { url = "https://files.pythonhosted.org/packages/7f/3e/5db95bcf282c52709639744ca2a8b149baccf648e39c8cc87553df9eae0c/urllib3-2.7.0-py3-none-any.whl", hash = "sha256:9fb4c81ebbb1ce9531cce37674bbc6f1360472bc18ca9a553ede278ef7276897", size = 131087, upload-time = "2026-05-07T16:13:17.151Z" },
 ]
 
 [[package]]


### PR DESCRIPTION
## Why

Clears the remaining **2 HIGH** dependency findings against `uv.lock` that were surfaced by the Trivy baseline in #131 and tracked in #132. Both are fixed in `urllib3` 2.7.0.

## CVEs cleared

| ID | Title |
|---|---|
| CVE-2026-44431 | Sensitive headers forwarded across origins in proxied low-level redirects |
| CVE-2026-44432 | Decompression-bomb safeguards bypassed in parts of the streaming API |

## What

- `pyproject.toml`: `urllib3==2.6.3` → `urllib3==2.7.0`. Exact-pin style preserved to match the surrounding pins in the `dependencies` list.
- `uv.lock`: regenerated via `uv lock`.

## ⚠️ Unrelated lockfile drift correction

`uv lock` also corrected a pre-existing inconsistency on `markdown`:

```diff
-    { name = "markdown", specifier = ">=3.10.2" },
+    { name = "markdown", specifier = "==3.7" },
```

The lockfile carried `markdown v3.10.2` while `pyproject.toml` pins `markdown==3.7`. uv brought the lockfile back in line with the pyproject pin. This is unrelated to the `urllib3` work but cannot be split out without leaving the lockfile in an inconsistent state on disk; the next person to run `uv lock` for any reason would reintroduce the same change. Net effect on the repo: lockfile and `pyproject.toml` are now consistent on the `markdown` pin.

If the markdown drift is preferred to be handled as a separate PR, this PR can be reworked once a decision is made on the intended `markdown` version — i.e., bump `pyproject.toml` to `markdown==3.10.2` (or `>=3.10.2`) instead, which would then make `uv lock` produce a 1-line change for `urllib3` only.

## Verification

Ran the same Trivy invocation locally as the workflow in #131:

```
trivy fs uv.lock \
  --scanners vuln \
  --severity HIGH,CRITICAL \
  --ignore-unfixed
```

Before: 2 HIGH findings (both on `urllib3`).
After: **0** HIGH/CRITICAL findings against `uv.lock`.

## Risk

- Patch-level/minor bump within `urllib3` 2.x. SemVer-compatible; no expected API breaks for consumers.
- `markdown` 3.10.2 → 3.7 is a *downgrade* in the on-disk environment of anyone who currently has the stale lockfile installed. Strictly speaking this is restoring the lockfile to match what `pyproject.toml` already required, but consumers who relied on 3.10.x features will see a regression. If 3.10.x is actually wanted, the fix is to bump the `pyproject.toml` pin in a separate change rather than leaving the lockfile out of sync.

## Out of scope

- `fast-xml-builder` and `fast-xml-parser` findings in `frontend/package-lock.json` — separate item in #132.
- The 3 Terraform misconfigurations — separate items in #132.

Refs: #131, #132, #133

---
Pull Request opened by [Augment Code](https://www.augmentcode.com/) with guidance from the PR author