### PR TITLE
feat: add Semgrep SAST workflow for enhanced security scanning

### DIFF
--- a/.github/workflows/semgrep.yml
+++ b/.github/workflows/semgrep.yml
@@ -1,0 +1,86 @@
+name: Semgrep SAST
+
+on:
+  push:
+    branches:
+      - main
+    paths-ignore:
+      - "docs/**"
+      - "**/*.md"
+  pull_request:
+    branches:
+      - main
+    types: [opened, synchronize, reopened]
+    paths-ignore:
+      - "docs/**"
+      - "**/*.md"
+  schedule:
+    # Re-scan weekly alongside the existing Trivy / CodeQL schedule
+    - cron: "0 8 * * 1"
+  workflow_dispatch:
+
+concurrency:
+  group: semgrep-${{ github.ref }}
+  cancel-in-progress: true
+
+permissions:
+  contents: read
+  security-events: write
+  pull-requests: read
+
+jobs:
+  semgrep:
+    name: Semgrep (${{ matrix.language }})
+    runs-on: ubuntu-latest
+    container:
+      image: semgrep/semgrep
+    strategy:
+      fail-fast: false
+      matrix:
+        include:
+          - language: ts
+            paths:
+              - "frontend/**"
+          - language: py
+            paths:
+              - "backend/**"
+    steps:
+      - uses: actions/checkout@v6
+
+      - name: Run Semgrep
+        run: >
+          semgrep ci
+          --config auto
+          --config .semgrep.yml
+          --include "${{ matrix.paths }}"
+          --sarif
+          --output semgrep-results.sarif
+          --error
+          --severity ERROR
+        env:
+          SEMGREP_RULES: >-
+            p/typescript
+            p/python
+            p/owasp-top-ten
+            p/security-audit
+            p/secrets
+        continue-on-error: true
+
+      - name: Upload SARIF to Code Scanning
+        if: always()
+        continue-on-error: true
+        uses: github/codeql-action/upload-sarif@v3
+        with:
+          sarif_file: semgrep-results.sarif
+          category: semgrep-${{ matrix.language }}
+
+      - name: Job summary
+        if: always()
+        run: |
+          {
+            echo "## Semgrep SAST — ${{ matrix.language }}"
+            echo ""
+            echo "- Ref: \`${{ github.ref }}\`"
+            echo "- Commit: \`${{ github.sha }}\`"
+            echo "- Config: \`auto\` + \`.semgrep.yml\`"
+          } >> "$GITHUB_STEP_SUMMARY"

--- a/.semgrep.yml
+++ b/.semgrep.yml
@@ -1,0 +1,101 @@
+rules:
+  # --- TypeScript / JavaScript rules ---
+
+  - id: hardcoded-secret-value
+    patterns:
+      - pattern-either:
+          - pattern: |
+              const $KEY = "..."
+          - pattern: |
+              let $KEY = "..."
+      - metavariable-regex:
+          metavariable: $KEY
+          regex: "(?i)(api_?key|secret|token|password|auth)"
+    message: >
+      Possible hardcoded secret detected in variable `$KEY`.
+      Move secrets to environment variables or a secrets manager.
+    severity: ERROR
+    languages: [typescript, javascript]
+    metadata:
+      cwe: "CWE-798: Use of Hard-coded Credentials"
+      owasp: "A07:2021 - Identification and Authentication Failures"
+      category: security
+
+  - id: dangerously-set-inner-html
+    pattern: |
+      dangerouslySetInnerHTML={{ __html: ... }}
+    message: >
+      Setting innerHTML via `dangerouslySetInnerHTML` can lead to XSS.
+      Sanitize user input before rendering.
+    severity: WARNING
+    languages: [typescript, javascript]
+    metadata:
+      cwe: "CWE-79: Cross-site Scripting (XSS)"
+      owasp: "A03:2021 - Injection"
+      category: security
+
+  - id: missing-csrf-protection
+    pattern-either:
+      - pattern: |
+          fetch("...", { method: "POST", ... })
+      - pattern: |
+          axios.post("...", ...)
+    message: >
+      POST request detected. Ensure CSRF protection is in place for
+      state-changing API calls.
+    severity: WARNING
+    languages: [typescript, javascript]
+    metadata:
+      cwe: "CWE-352: Cross-Site Request Forgery (CSRF)"
+      owasp: "A01:2021 - Broken Access Control"
+      category: security
+
+  # --- Python rules ---
+
+  - id: hardcoded-secret-python
+    patterns:
+      - pattern-either:
+          - pattern: |
+              $KEY = "..."
+          - pattern: |
+              $KEY = '...'
+      - metavariable-regex:
+          metavariable: $KEY
+          regex: "(?i)(api_?key|secret|token|password|auth|credentials)"
+    message: >
+      Possible hardcoded secret in variable `$KEY`.
+      Use environment variables or a secrets manager.
+    severity: ERROR
+    languages: [python]
+    metadata:
+      cwe: "CWE-798: Use of Hard-coded Credentials"
+      category: security
+
+  - id: use-of-eval
+    pattern: eval(...)
+    message: >
+      Use of `eval()` is dangerous and may lead to code injection.
+      Avoid eval or ensure input is fully sanitized.
+    severity: ERROR
+    languages: [python]
+    metadata:
+      cwe: "CWE-95: Improper Neutralization of Directives in Dynamically Evaluated Code"
+      category: security
+
+  - id: sql-injection-python
+    pattern-either:
+      - pattern: |
+          $CURSOR.execute(f"...")
+      - pattern: |
+          $CURSOR.execute("..." + ...)
+      - pattern: |
+          $CURSOR.execute("...".format(...))
+    message: >
+      Possible SQL injection. Use parameterized queries instead of
+      string formatting.
+    severity: ERROR
+    languages: [python]
+    metadata:
+      cwe: "CWE-89: SQL Injection"
+      owasp: "A03:2021 - Injection"
+      category: security


### PR DESCRIPTION
## Summary

Adds [Semgrep](https://semgrep.dev/) as an additional SAST tool alongside the existing Trivy and CodeQL security scanning workflows.

Closes #123

## Changes

### New files

- **`.github/workflows/semgrep.yml`** — Semgrep SAST workflow that runs on:
  - Push to `main`
  - Pull requests to `main`
  - Weekly schedule (Monday 08:00 UTC)
  - Manual `workflow_dispatch`
  
  Scans TypeScript (frontend) and Python (backend) independently using a matrix strategy. Uploads SARIF results to Code Scanning.

- **`.semgrep.yml`** — Custom Semgrep rules covering:
  - **Hardcoded secrets** (TypeScript & Python): Detects variable assignments with names matching common secret patterns (`api_key`, `secret`, `token`, `password`, etc.)
  - **`dangerouslySetInnerHTML`**: Flags XSS-vulnerable React rendering
  - **CSRF protection**: Alerts on unverified POST requests
  - **`eval()` usage**: Detects Python code injection vectors
  - **SQL injection**: Identifies string-formatted SQL queries

## How it complements existing tools

| Tool | Strength | Gap |
|---|---|---|
| Trivy | Dependency CVEs, secrets, IaC | No source-level SAST |
| CodeQL | Deep semantic analysis | Slower, fewer custom rules |
| **Semgrep** | **Fast PR-diff scanning, custom rules** | **Fills the PR feedback gap** |

Semgrep's `config auto` pulls from the public Semgrep registry, adding OWASP Top 10, security-audit, and secrets rule packs on top of the custom rules in `.semgrep.yml`.

## Known limitations

- Semgrep runs in a container (`semgrep/semgrep`); GitHub Actions' SARIF upload requires `security-events: write`, which is granted in the workflow permissions.
- The workflow does not require repository secrets; it uses free public rulesets.