### PR TITLE
feat: Migrating from Mailgun + Enhancing Admin Dashboard

### DIFF
--- a/backend/app/config.py
+++ b/backend/app/config.py
@@ -21,6 +21,7 @@ class Settings(BaseSettings):
     user_state_table: str
     testimonials_table: str
     notifications_table: str
+    broadcasts_table: str
 
     # Secrets Manager secret names
     discord_secret_name: str

--- a/backend/app/config.py
+++ b/backend/app/config.py
@@ -53,8 +53,8 @@ class Settings(BaseSettings):
     content_registry_bucket: str = ""
     total_module_pages: int = 0
     session_token_lifetime_hours: int = 8
-    mailgun_domain: str = ""
-    mailgun_param_name: str = ""
+    ses_sender_email: str = "noreply@devsecblueprint.com"
+    ses_region: str = "us-east-2"
     testimonial_notify_email: str = "info@devsecblueprint.com"
 
     model_config = {

--- a/backend/app/config.py
+++ b/backend/app/config.py
@@ -21,7 +21,7 @@ class Settings(BaseSettings):
     user_state_table: str
     testimonials_table: str
     notifications_table: str
-    broadcasts_table: str
+    broadcasts_table: str = ""
 
     # Secrets Manager secret names
     discord_secret_name: str

--- a/backend/app/routers/admin.py
+++ b/backend/app/routers/admin.py
@@ -1202,3 +1202,232 @@ async def delete_contributor_role(
     except Exception as e:
         logger.error("Error deleting contributor role for %s: %s", user_id, e)
         raise HTTPException(status_code=500, detail="Internal server error")
+
+
+# ---------------------------------------------------------------------------
+# Walkthrough Access Tier Management (paywall)
+# ---------------------------------------------------------------------------
+
+
+@router.get("/walkthroughs/access-tiers")
+async def get_all_walkthrough_access_tiers(
+    admin: dict = Depends(require_admin),
+    settings: Settings = Depends(get_settings),
+) -> JSONResponse:
+    """Get access tiers for all walkthroughs (admin view).
+
+    Returns a dict mapping walkthrough_id -> access_tier for walkthroughs
+    with explicit tier records. Unlisted walkthroughs default to FREE.
+    """
+    try:
+        svc = AdminService(settings)
+        tiers = svc.get_all_walkthrough_access_tiers()
+        return JSONResponse(status_code=200, content={"access_tiers": tiers})
+    except Exception as e:
+        logger.error("Error fetching walkthrough access tiers: %s", e)
+        raise HTTPException(status_code=500, detail="Internal server error")
+
+
+@router.put("/walkthroughs/{walkthrough_id}/access-tier")
+async def set_walkthrough_access_tier(
+    walkthrough_id: str,
+    request: Request,
+    admin: dict = Depends(require_admin),
+    settings: Settings = Depends(get_settings),
+) -> JSONResponse:
+    """Set the access tier for a walkthrough.
+
+    Body: { "access_tier": "FREE" | "BUILDER" }
+    """
+    try:
+        body = await request.body()
+        if not body:
+            raise HTTPException(status_code=400, detail="Request body is required")
+
+        try:
+            payload = json.loads(body.decode("utf-8"))
+        except (json.JSONDecodeError, UnicodeDecodeError):
+            raise HTTPException(status_code=400, detail="Invalid request body")
+
+        access_tier = payload.get("access_tier", "").strip().upper()
+        if not access_tier:
+            raise HTTPException(status_code=400, detail="access_tier is required")
+
+        admin_user_id = (
+            admin.get("github_login")
+            or admin.get("gitlab_login")
+            or admin.get("bitbucket_login")
+            or admin.get("sub", "unknown")
+        )
+
+        svc = AdminService(settings)
+
+        try:
+            result = svc.set_walkthrough_access_tier(
+                walkthrough_id=walkthrough_id,
+                access_tier=access_tier,
+                set_by=admin_user_id,
+            )
+        except ValueError as e:
+            raise HTTPException(status_code=400, detail=str(e))
+
+        return JSONResponse(
+            status_code=200,
+            content={"message": "Access tier updated", "data": result},
+        )
+
+    except HTTPException:
+        raise
+    except Exception as e:
+        logger.error(
+            "Error setting access tier for walkthrough %s: %s", walkthrough_id, e
+        )
+        raise HTTPException(status_code=500, detail="Internal server error")
+
+
+@router.delete("/walkthroughs/{walkthrough_id}/access-tier")
+async def delete_walkthrough_access_tier(
+    walkthrough_id: str,
+    admin: dict = Depends(require_admin),
+    settings: Settings = Depends(get_settings),
+) -> JSONResponse:
+    """Reset a walkthrough's access tier to FREE (removes the record)."""
+    try:
+        svc = AdminService(settings)
+        # Setting to FREE effectively removes the paywall
+        admin_user_id = (
+            admin.get("github_login")
+            or admin.get("gitlab_login")
+            or admin.get("bitbucket_login")
+            or admin.get("sub", "unknown")
+        )
+        svc.set_walkthrough_access_tier(
+            walkthrough_id=walkthrough_id,
+            access_tier="FREE",
+            set_by=admin_user_id,
+        )
+        return JSONResponse(
+            status_code=200,
+            content={"message": "Access tier reset to FREE"},
+        )
+    except Exception as e:
+        logger.error(
+            "Error resetting access tier for walkthrough %s: %s", walkthrough_id, e
+        )
+        raise HTTPException(status_code=500, detail="Internal server error")
+
+
+# ---------------------------------------------------------------------------
+# Broadcast Notifications (admin)
+# ---------------------------------------------------------------------------
+
+
+@router.post("/broadcasts")
+async def create_broadcast(
+    request: Request,
+    background_tasks: BackgroundTasks,
+    admin: dict = Depends(require_admin),
+    settings: Settings = Depends(get_settings),
+) -> JSONResponse:
+    """Create a broadcast notification and send email to all users.
+
+    Body: { "title": "...", "message": "...(markdown)...", "link": "..." (optional) }
+    """
+    try:
+        body = await request.body()
+        if not body:
+            raise HTTPException(status_code=400, detail="Request body is required")
+
+        try:
+            payload = json.loads(body.decode("utf-8"))
+        except (json.JSONDecodeError, UnicodeDecodeError):
+            raise HTTPException(status_code=400, detail="Invalid request body")
+
+        title = payload.get("title", "").strip()
+        message = payload.get("message", "").strip()
+        link = payload.get("link", "").strip()
+
+        if not title:
+            raise HTTPException(status_code=400, detail="Title is required")
+        if len(title) > 100:
+            raise HTTPException(
+                status_code=400, detail="Title must be 100 characters or less"
+            )
+        if not message:
+            raise HTTPException(status_code=400, detail="Message is required")
+        if len(message) > 2000:
+            raise HTTPException(
+                status_code=400, detail="Message must be 2000 characters or less"
+            )
+
+        admin_username = (
+            admin.get("github_login")
+            or admin.get("gitlab_login")
+            or admin.get("bitbucket_login")
+            or admin.get("sub", "unknown")
+        )
+
+        from app.services.broadcast_service import BroadcastService
+
+        svc = BroadcastService(settings)
+        broadcast = svc.create_broadcast(
+            title=title,
+            message=message,
+            created_by=admin_username,
+            link=link,
+        )
+
+        # Enqueue email delivery as background task
+        from app.services.broadcast_email import send_broadcast_emails
+
+        background_tasks.add_task(send_broadcast_emails, broadcast, settings)
+
+        return JSONResponse(
+            status_code=201,
+            content={"message": "Broadcast created", "broadcast": broadcast},
+        )
+
+    except HTTPException:
+        raise
+    except Exception as e:
+        logger.error("Error creating broadcast: %s", e)
+        raise HTTPException(status_code=500, detail="Internal server error")
+
+
+@router.get("/broadcasts")
+async def list_broadcasts(
+    admin: dict = Depends(require_admin),
+    settings: Settings = Depends(get_settings),
+) -> JSONResponse:
+    """List all active broadcasts (admin view)."""
+    try:
+        from app.services.broadcast_service import BroadcastService
+
+        svc = BroadcastService(settings)
+        broadcasts = svc.get_all_broadcasts()
+        return JSONResponse(status_code=200, content={"broadcasts": broadcasts})
+    except Exception as e:
+        logger.error("Error listing broadcasts: %s", e)
+        raise HTTPException(status_code=500, detail="Internal server error")
+
+
+@router.delete("/broadcasts/{broadcast_id:path}")
+async def delete_broadcast(
+    broadcast_id: str,
+    admin: dict = Depends(require_admin),
+    settings: Settings = Depends(get_settings),
+) -> JSONResponse:
+    """Delete a broadcast permanently."""
+    try:
+        from app.services.broadcast_service import BroadcastService
+
+        svc = BroadcastService(settings)
+        success = svc.delete_broadcast(broadcast_id)
+        if not success:
+            raise HTTPException(status_code=500, detail="Failed to delete broadcast")
+        return JSONResponse(status_code=200, content={"message": "Broadcast deleted"})
+    except HTTPException:
+        raise
+    except Exception as e:
+        logger.error("Error deleting broadcast %s: %s", broadcast_id, e)
+        raise HTTPException(status_code=500, detail="Internal server error")

--- a/backend/app/routers/admin.py
+++ b/backend/app/routers/admin.py
@@ -13,10 +13,17 @@ are in content.py and are NOT duplicated here.
 Requirements: 4.3
 """
 
+import csv
+import io
 import json
 import logging
+import math
+import time as time_mod
+from collections import defaultdict
+from datetime import datetime, timezone, timedelta
 from typing import Any
 
+import boto3 as boto3_mod
 from fastapi import APIRouter, BackgroundTasks, Depends, HTTPException, Request
 from fastapi.responses import JSONResponse, Response
 
@@ -26,6 +33,13 @@ from app.dependencies import get_settings
 from app.services.admin_discord import AdminDiscordService
 from app.services.admin_service import AdminService
 from app.services.membership_db import MembershipDB
+from app.services.badge_service import calculate_user_badges, get_badges_earned_count
+from app.services.content_registry import get_registry_service
+from app.services.broadcast_service import BroadcastService
+from app.services.broadcast_email import send_broadcast_emails
+from app.services.notification_service import create_notification
+from app.services.email import send_review_notification_to_learner
+from app.background.discord_tasks import enqueue_discord_sync
 
 logger = logging.getLogger(__name__)
 
@@ -83,8 +97,6 @@ async def admin_trigger_sync(
     result = service.trigger_sync(admin_user_id, user_id, reason)
 
     # Enqueue background sync task
-    from app.background.discord_tasks import enqueue_discord_sync
-
     enqueue_discord_sync(background_tasks, user_id, "admin_sync", reason)
 
     return JSONResponse(status_code=200, content=result)
@@ -166,9 +178,6 @@ async def get_analytics(
         total_capstone_submissions = svc.get_total_capstone_submissions_count()
         badge_stats = svc.get_all_badge_stats()
         quiz_stats = svc.get_all_quiz_stats()
-
-        from datetime import datetime, timezone, timedelta
-        from collections import defaultdict
 
         registered_user_ids = {user["user_id"] for user in all_registered}
         users_with_progress: set = set()
@@ -344,8 +353,6 @@ async def get_registry_status(
 ) -> JSONResponse:
     """Get content registry health and cache status."""
     try:
-        from app.services.content_registry import get_registry_service
-
         s3_bucket = settings.content_registry_bucket
         if not s3_bucket:
             raise HTTPException(status_code=503, detail="Service unavailable")
@@ -389,8 +396,6 @@ async def get_module_health(
 ) -> JSONResponse:
     """Get module validation metrics and health status."""
     try:
-        from app.services.content_registry import get_registry_service
-
         s3_bucket = settings.content_registry_bucket
         if not s3_bucket:
             raise HTTPException(status_code=503, detail="Service unavailable")
@@ -468,10 +473,6 @@ async def user_search(
             )
 
         svc = AdminService(settings)
-        from app.services.badge_service import (
-            calculate_user_badges,
-            get_badges_earned_count,
-        )
 
         all_users = svc.get_all_registered_users()
 
@@ -564,8 +565,6 @@ async def list_users(
 
     Query params: page (default 1), page_size (default 20, max 100), search (optional).
     """
-    import math
-
     try:
         try:
             page = int(request.query_params.get("page", "1"))
@@ -647,7 +646,6 @@ async def get_admin_user_profile(
     """Get detailed user profile with stats and badges (admin view)."""
     try:
         svc = AdminService(settings)
-        from app.services.badge_service import calculate_user_badges
 
         if not user_id:
             raise HTTPException(status_code=400, detail="User ID is required")
@@ -733,14 +731,10 @@ async def get_active_sessions(
     settings: Settings = Depends(get_settings),
 ) -> JSONResponse:
     """Get all active sessions (latest session per user, newest first)."""
-    import time as time_mod
-
     try:
         table_name = settings.progress_table
         if not table_name:
             raise HTTPException(status_code=503, detail="Service unavailable")
-
-        import boto3 as boto3_mod
 
         dynamodb = boto3_mod.client("dynamodb")
         now = int(time_mod.time())
@@ -837,9 +831,6 @@ async def export_users(
     settings: Settings = Depends(get_settings),
 ) -> Response:
     """Export all users with their stats as CSV."""
-    import csv
-    import io
-
     try:
         svc = AdminService(settings)
 
@@ -911,9 +902,6 @@ async def export_capstone_submissions(
     settings: Settings = Depends(get_settings),
 ) -> Response:
     """Export all capstone submissions as CSV."""
-    import csv
-    import io
-
     try:
         svc = AdminService(settings)
 
@@ -979,7 +967,6 @@ async def submit_review(
     """
     try:
         svc = AdminService(settings)
-        from app.services.notification_service import create_notification
 
         username = (
             admin.get("github_login")
@@ -1049,8 +1036,6 @@ async def submit_review(
         try:
             profile = svc.get_user_profile(target_user_id)
             if profile and profile.get("email"):
-                from app.services.email import send_review_notification_to_learner
-
                 send_review_notification_to_learner(
                     email=profile["email"],
                     username=profile.get("username", ""),
@@ -1367,8 +1352,6 @@ async def create_broadcast(
             or admin.get("sub", "unknown")
         )
 
-        from app.services.broadcast_service import BroadcastService
-
         svc = BroadcastService(settings)
         broadcast = svc.create_broadcast(
             title=title,
@@ -1378,8 +1361,6 @@ async def create_broadcast(
         )
 
         # Enqueue email delivery as background task
-        from app.services.broadcast_email import send_broadcast_emails
-
         background_tasks.add_task(send_broadcast_emails, broadcast, settings)
 
         return JSONResponse(
@@ -1401,8 +1382,6 @@ async def list_broadcasts(
 ) -> JSONResponse:
     """List all active broadcasts (admin view)."""
     try:
-        from app.services.broadcast_service import BroadcastService
-
         svc = BroadcastService(settings)
         broadcasts = svc.get_all_broadcasts()
         return JSONResponse(status_code=200, content={"broadcasts": broadcasts})
@@ -1419,8 +1398,6 @@ async def delete_broadcast(
 ) -> JSONResponse:
     """Delete a broadcast permanently."""
     try:
-        from app.services.broadcast_service import BroadcastService
-
         svc = BroadcastService(settings)
         success = svc.delete_broadcast(broadcast_id)
         if not success:

--- a/backend/app/routers/admin.py
+++ b/backend/app/routers/admin.py
@@ -610,6 +610,11 @@ async def list_users(
         end = start + page_size
         users_page = all_users[start:end]
 
+        # Enrich page of users with contributor roles
+        for user in users_page:
+            role_data = svc.get_contributor_role(user["user_id"])
+            user["contributor_role"] = role_data.get("role") if role_data else None
+
         return JSONResponse(
             status_code=200,
             content={
@@ -683,6 +688,13 @@ async def get_admin_user_profile(
             )
             walkthrough_progress = []
 
+        # Fetch contributor role
+        contributor_role = None
+        try:
+            contributor_role = svc.get_contributor_role(user_id)
+        except Exception as e:
+            logger.warning("Failed to get contributor role for user %s: %s", user_id, e)
+
         return JSONResponse(
             status_code=200,
             content={
@@ -698,6 +710,7 @@ async def get_admin_user_profile(
                 },
                 "badges": badges,
                 "walkthrough_progress": walkthrough_progress,
+                "contributor_role": contributor_role,
             },
         )
 
@@ -1079,3 +1092,113 @@ async def get_review_admin(
     except Exception as e:
         logger.error("Error in get_review_admin: %s", e)
         raise HTTPException(status_code=500, detail="Service temporarily unavailable")
+
+
+# ---------------------------------------------------------------------------
+# Contributor Role Mapping (admin override)
+# ---------------------------------------------------------------------------
+
+
+@router.get("/users/{user_id}/contributor-role")
+async def get_contributor_role(
+    user_id: str,
+    admin: dict = Depends(require_admin),
+    settings: Settings = Depends(get_settings),
+) -> JSONResponse:
+    """Get the contributor role for a user (admin view)."""
+    try:
+        svc = AdminService(settings)
+        role_data = svc.get_contributor_role(user_id)
+        return JSONResponse(
+            status_code=200,
+            content={"contributor_role": role_data},
+        )
+    except Exception as e:
+        logger.error("Error getting contributor role for %s: %s", user_id, e)
+        raise HTTPException(status_code=500, detail="Internal server error")
+
+
+@router.put("/users/{user_id}/contributor-role")
+async def set_contributor_role(
+    user_id: str,
+    request: Request,
+    admin: dict = Depends(require_admin),
+    settings: Settings = Depends(get_settings),
+) -> JSONResponse:
+    """Assign or update a contributor role for a user.
+
+    Body: { "role": "contributor"|"maintainer"|"reviewer"|"mentor", "note": "optional" }
+    """
+    try:
+        body = await request.body()
+        if not body:
+            raise HTTPException(status_code=400, detail="Request body is required")
+
+        try:
+            payload = json.loads(body.decode("utf-8"))
+        except (json.JSONDecodeError, UnicodeDecodeError):
+            raise HTTPException(status_code=400, detail="Invalid request body")
+
+        role = payload.get("role", "").strip()
+        note = payload.get("note", "").strip()
+
+        if not role:
+            raise HTTPException(status_code=400, detail="Role is required")
+
+        admin_user_id = (
+            admin.get("github_login")
+            or admin.get("gitlab_login")
+            or admin.get("bitbucket_login")
+            or admin.get("sub", "unknown")
+        )
+
+        svc = AdminService(settings)
+
+        try:
+            result = svc.set_contributor_role(
+                user_id=user_id,
+                role=role,
+                assigned_by=admin_user_id,
+                note=note,
+            )
+        except ValueError as e:
+            raise HTTPException(status_code=400, detail=str(e))
+
+        return JSONResponse(
+            status_code=200,
+            content={
+                "message": "Contributor role assigned",
+                "contributor_role": result,
+            },
+        )
+
+    except HTTPException:
+        raise
+    except Exception as e:
+        logger.error("Error setting contributor role for %s: %s", user_id, e)
+        raise HTTPException(status_code=500, detail="Internal server error")
+
+
+@router.delete("/users/{user_id}/contributor-role")
+async def delete_contributor_role(
+    user_id: str,
+    admin: dict = Depends(require_admin),
+    settings: Settings = Depends(get_settings),
+) -> JSONResponse:
+    """Remove a user's contributor role."""
+    try:
+        svc = AdminService(settings)
+        success = svc.delete_contributor_role(user_id)
+        if not success:
+            raise HTTPException(
+                status_code=500, detail="Failed to remove contributor role"
+            )
+        return JSONResponse(
+            status_code=200,
+            content={"message": "Contributor role removed"},
+        )
+    except HTTPException:
+        raise
+    except Exception as e:
+        logger.error("Error deleting contributor role for %s: %s", user_id, e)
+        raise HTTPException(status_code=500, detail="Internal server error")

--- a/backend/app/routers/content.py
+++ b/backend/app/routers/content.py
@@ -23,12 +23,40 @@ import json
 import logging
 import random
 import re
+from datetime import datetime, timezone
 from typing import Any
 
 from fastapi import APIRouter, Depends, HTTPException, Request
 from fastapi.responses import JSONResponse
 
 from app.auth.jwt import get_current_user, require_admin
+from app.dependencies import get_settings
+from app.config import Settings
+from app.services.walkthrough_service import (
+    get_walkthrough_progress as _get_progress,
+    update_walkthrough_progress as _update_progress,
+)
+from app.services.admin_service import AdminService
+from app.services.membership_db import MembershipDB
+from app.services.notification_service import (
+    get_notifications as _get_notifications,
+    delete_notification as _delete_notification,
+)
+from app.services.broadcast_service import BroadcastService
+from app.services.quiz_service import (
+    submit_quiz,
+    QuizNotFoundError,
+    RegistryUnavailableError,
+)
+from app.services.testimonial_service import (
+    create_testimonial,
+    get_testimonial,
+    update_testimonial,
+    get_testimonials_by_status,
+    get_all_testimonials,
+    delete_testimonial,
+)
+from app.services.email import send_testimonial_notification
 
 logger = logging.getLogger(__name__)
 
@@ -56,10 +84,6 @@ async def get_walkthrough_progress(
 
     Requirements: 11.1, 11.2, 11.3, 11.4, 11.5, 11.6
     """
-    from app.services.walkthrough_service import (
-        get_walkthrough_progress as _get_progress,
-    )
-
     try:
         user_id = user["sub"]
         progress = _get_progress(user_id, walkthrough_id)
@@ -88,12 +112,6 @@ async def update_walkthrough_progress(
 
     Requirements: 10.6, 11.8
     """
-    from app.services.walkthrough_service import (
-        update_walkthrough_progress as update_progress,
-    )
-    from app.services.admin_service import AdminService
-    from app.dependencies import get_settings as _get_settings
-
     user_id = user["sub"]
 
     # Parse body
@@ -111,14 +129,12 @@ async def update_walkthrough_progress(
 
     # Check if walkthrough is behind paywall
     try:
-        settings = _get_settings()
+        settings = get_settings()
         svc = AdminService(settings)
         access_tier = svc.get_walkthrough_access_tier(walkthrough_id)
 
         if access_tier == "BUILDER":
             # Verify user has BUILDER membership
-            from app.services.membership_db import MembershipDB
-
             membership_db = MembershipDB(settings)
             membership_item = membership_db.get_membership(user_id)
 
@@ -141,7 +157,7 @@ async def update_walkthrough_progress(
         # Fail open — don't block progress if tier check fails
 
     try:
-        update_progress(user_id, walkthrough_id, status)
+        _update_progress(user_id, walkthrough_id, status)
     except ValueError:
         raise HTTPException(status_code=400, detail="Invalid status value")
     except Exception as e:
@@ -167,11 +183,8 @@ async def get_walkthrough_access_tiers(
     Returns a dict mapping walkthrough_id -> access_tier for walkthroughs
     that require BUILDER tier. Unlisted walkthroughs are FREE.
     """
-    from app.services.admin_service import AdminService
-    from app.dependencies import get_settings as _get_settings
-
     try:
-        settings = _get_settings()
+        settings = get_settings()
         svc = AdminService(settings)
         tiers = svc.get_all_walkthrough_access_tiers()
         # Only return walkthroughs that are locked (BUILDER)
@@ -196,12 +209,6 @@ async def quiz_submit(
 
     Requirements: 1.1, 1.2, 1.3, 1.4, 1.5, 8.1, 8.3, 8.4, 8.5, 8.6, 8.8
     """
-    from app.services.quiz_service import (
-        submit_quiz,
-        QuizNotFoundError,
-        RegistryUnavailableError,
-    )
-
     user_id = user["sub"]
 
     # Parse body
@@ -275,8 +282,6 @@ def _validate_testimonial_fields(
 def _send_notification_email(display_name: str, linkedin_url: str, quote: str) -> None:
     """Fire-and-forget email notification to admin."""
     try:
-        from app.services.email import send_testimonial_notification
-
         result = send_testimonial_notification(display_name, linkedin_url, quote)
         if not result:
             logger.warning(
@@ -295,12 +300,6 @@ async def submit_testimonial(
 
     Requirements: 7.1, 7.6, 7.8, 8.1, 8.2, 8.3, 8.4, 8.5, 2.1, 11.1, 11.4, 11.5
     """
-    from app.services.testimonial_service import (
-        create_testimonial,
-        get_testimonial,
-        update_testimonial,
-    )
-
     user_id = user["sub"]
 
     # Parse body
@@ -377,8 +376,6 @@ async def get_my_testimonial(
 
     Requirements: 7.2, 7.6
     """
-    from app.services.testimonial_service import get_testimonial
-
     user_id = user["sub"]
 
     try:
@@ -399,8 +396,6 @@ async def get_approved_testimonials() -> JSONResponse:
 
     Requirements: 7.3, 7.9, 7.10, 2.2
     """
-    from app.services.testimonial_service import get_testimonials_by_status
-
     try:
         all_approved = get_testimonials_by_status("approved")
 
@@ -446,12 +441,10 @@ async def get_notifications(
 
     Requirements: 5.4, 5.6, 12.2
     """
-    from app.services.notification_service import get_notifications as get_notifs
-
     user_id = user["sub"]
 
     try:
-        notifications = get_notifs(user_id)
+        notifications = _get_notifications(user_id)
         return JSONResponse(status_code=200, content={"notifications": notifications})
     except Exception as e:
         logger.error(f"Error in get_notifications: {str(e)}")
@@ -467,14 +460,10 @@ async def delete_notification(
 
     Requirements: 5.5, 5.6, 12.2
     """
-    from app.services.notification_service import (
-        delete_notification as delete_notif,
-    )
-
     user_id = user["sub"]
 
     try:
-        delete_notif(user_id, notification_id)
+        _delete_notification(user_id, notification_id)
         return JSONResponse(
             status_code=200, content={"message": "Notification deleted"}
         )
@@ -497,11 +486,6 @@ async def admin_list_testimonials(
 
     Requirements: 7.4, 7.7, 5.10
     """
-    from app.services.testimonial_service import (
-        get_testimonials_by_status,
-        get_all_testimonials,
-    )
-
     username = (
         user.get("github_login")
         or user.get("gitlab_login")
@@ -550,14 +534,6 @@ async def admin_update_testimonial_status(
 
     Requirements: 7.5, 7.7, 2.3, 2.4, 2.5, 2.6, 5.10
     """
-    from datetime import datetime, timezone
-
-    from app.services.testimonial_service import (
-        get_testimonial,
-        update_testimonial,
-        delete_testimonial,
-    )
-
     username = (
         user.get("github_login")
         or user.get("gitlab_login")
@@ -679,13 +655,10 @@ async def get_unread_broadcasts(
     user: dict = Depends(get_current_user),
 ) -> JSONResponse:
     """Get unread broadcast notifications for the authenticated user."""
-    from app.services.broadcast_service import BroadcastService
-    from app.dependencies import get_settings as _get_settings
-
     user_id = user["sub"]
 
     try:
-        settings = _get_settings()
+        settings = get_settings()
         svc = BroadcastService(settings)
         broadcasts = svc.get_unread_broadcasts(user_id)
         return JSONResponse(status_code=200, content={"broadcasts": broadcasts})
@@ -700,13 +673,10 @@ async def dismiss_broadcast(
     user: dict = Depends(get_current_user),
 ) -> JSONResponse:
     """Dismiss a single broadcast for the authenticated user."""
-    from app.services.broadcast_service import BroadcastService
-    from app.dependencies import get_settings as _get_settings
-
     user_id = user["sub"]
 
     try:
-        settings = _get_settings()
+        settings = get_settings()
         svc = BroadcastService(settings)
         svc.dismiss_broadcast(user_id, broadcast_id)
         return JSONResponse(status_code=200, content={"message": "Broadcast dismissed"})
@@ -725,13 +695,10 @@ async def dismiss_all_broadcasts(
     user: dict = Depends(get_current_user),
 ) -> JSONResponse:
     """Dismiss all unread broadcasts for the authenticated user."""
-    from app.services.broadcast_service import BroadcastService
-    from app.dependencies import get_settings as _get_settings
-
     user_id = user["sub"]
 
     try:
-        settings = _get_settings()
+        settings = get_settings()
         svc = BroadcastService(settings)
         unread = svc.get_unread_broadcasts(user_id)
         if unread:

--- a/backend/app/routers/content.py
+++ b/backend/app/routers/content.py
@@ -91,6 +91,8 @@ async def update_walkthrough_progress(
     from app.services.walkthrough_service import (
         update_walkthrough_progress as update_progress,
     )
+    from app.services.admin_service import AdminService
+    from app.dependencies import get_settings as _get_settings
 
     user_id = user["sub"]
 
@@ -107,6 +109,37 @@ async def update_walkthrough_progress(
     except json.JSONDecodeError:
         raise HTTPException(status_code=400, detail="Invalid request")
 
+    # Check if walkthrough is behind paywall
+    try:
+        settings = _get_settings()
+        svc = AdminService(settings)
+        access_tier = svc.get_walkthrough_access_tier(walkthrough_id)
+
+        if access_tier == "BUILDER":
+            # Verify user has BUILDER membership
+            from app.services.membership_db import MembershipDB
+
+            membership_db = MembershipDB(settings)
+            membership_item = membership_db.get_membership(user_id)
+
+            user_tier = "FREE"
+            if membership_item:
+                item_tier = membership_item.get("membership_tier", {}).get("S", "FREE")
+                item_status = membership_item.get("subscription_status", {}).get("S")
+                if item_tier == "BUILDER" and item_status in ("active", "past_due"):
+                    user_tier = "BUILDER"
+
+            if user_tier != "BUILDER":
+                raise HTTPException(
+                    status_code=403,
+                    detail="This walkthrough requires a Builder subscription",
+                )
+    except HTTPException:
+        raise
+    except Exception as e:
+        logger.warning("Failed to check walkthrough access tier: %s", e)
+        # Fail open — don't block progress if tier check fails
+
     try:
         update_progress(user_id, walkthrough_id, status)
     except ValueError:
@@ -118,6 +151,35 @@ async def update_walkthrough_progress(
     return JSONResponse(
         status_code=200, content={"message": "Progress updated successfully"}
     )
+
+
+# ---------------------------------------------------------------------------
+# Walkthrough Access Tiers (public, authenticated)
+# ---------------------------------------------------------------------------
+
+
+@router.get("/api/walkthroughs/access-tiers")
+async def get_walkthrough_access_tiers(
+    user: dict = Depends(get_current_user),
+) -> JSONResponse:
+    """Get access tiers for all walkthroughs.
+
+    Returns a dict mapping walkthrough_id -> access_tier for walkthroughs
+    that require BUILDER tier. Unlisted walkthroughs are FREE.
+    """
+    from app.services.admin_service import AdminService
+    from app.dependencies import get_settings as _get_settings
+
+    try:
+        settings = _get_settings()
+        svc = AdminService(settings)
+        tiers = svc.get_all_walkthrough_access_tiers()
+        # Only return walkthroughs that are locked (BUILDER)
+        locked = {wt_id: tier for wt_id, tier in tiers.items() if tier == "BUILDER"}
+        return JSONResponse(status_code=200, content={"access_tiers": locked})
+    except Exception as e:
+        logger.error("Error fetching walkthrough access tiers: %s", e)
+        return JSONResponse(status_code=200, content={"access_tiers": {}})
 
 
 # ---------------------------------------------------------------------------
@@ -605,3 +667,79 @@ async def admin_update_testimonial_status(
     except Exception as e:
         logger.error(f"Error updating testimonial status: {e}")
         raise HTTPException(status_code=500, detail="Internal server error")
+
+
+# ---------------------------------------------------------------------------
+# Broadcast Notifications (user-facing)
+# ---------------------------------------------------------------------------
+
+
+@router.get("/api/broadcasts/unread")
+async def get_unread_broadcasts(
+    user: dict = Depends(get_current_user),
+) -> JSONResponse:
+    """Get unread broadcast notifications for the authenticated user."""
+    from app.services.broadcast_service import BroadcastService
+    from app.dependencies import get_settings as _get_settings
+
+    user_id = user["sub"]
+
+    try:
+        settings = _get_settings()
+        svc = BroadcastService(settings)
+        broadcasts = svc.get_unread_broadcasts(user_id)
+        return JSONResponse(status_code=200, content={"broadcasts": broadcasts})
+    except Exception as e:
+        logger.error("Error fetching unread broadcasts for user %s: %s", user_id, e)
+        return JSONResponse(status_code=200, content={"broadcasts": []})
+
+
+@router.post("/api/broadcasts/{broadcast_id:path}/dismiss")
+async def dismiss_broadcast(
+    broadcast_id: str,
+    user: dict = Depends(get_current_user),
+) -> JSONResponse:
+    """Dismiss a single broadcast for the authenticated user."""
+    from app.services.broadcast_service import BroadcastService
+    from app.dependencies import get_settings as _get_settings
+
+    user_id = user["sub"]
+
+    try:
+        settings = _get_settings()
+        svc = BroadcastService(settings)
+        svc.dismiss_broadcast(user_id, broadcast_id)
+        return JSONResponse(status_code=200, content={"message": "Broadcast dismissed"})
+    except Exception as e:
+        logger.error(
+            "Error dismissing broadcast %s for user %s: %s",
+            broadcast_id,
+            user_id,
+            e,
+        )
+        raise HTTPException(status_code=500, detail="Failed to dismiss broadcast")
+
+
+@router.post("/api/broadcasts/dismiss-all")
+async def dismiss_all_broadcasts(
+    user: dict = Depends(get_current_user),
+) -> JSONResponse:
+    """Dismiss all unread broadcasts for the authenticated user."""
+    from app.services.broadcast_service import BroadcastService
+    from app.dependencies import get_settings as _get_settings
+
+    user_id = user["sub"]
+
+    try:
+        settings = _get_settings()
+        svc = BroadcastService(settings)
+        unread = svc.get_unread_broadcasts(user_id)
+        if unread:
+            broadcast_ids = [b["broadcast_id"] for b in unread]
+            svc.dismiss_all_broadcasts(user_id, broadcast_ids)
+        return JSONResponse(
+            status_code=200, content={"message": "All broadcasts dismissed"}
+        )
+    except Exception as e:
+        logger.error("Error dismissing all broadcasts for user %s: %s", user_id, e)
+        raise HTTPException(status_code=500, detail="Failed to dismiss broadcasts")

--- a/backend/app/routers/user.py
+++ b/backend/app/routers/user.py
@@ -132,6 +132,32 @@ def _get_user_progress_count(user_id: str, table_name: str) -> int:
     return response.get("Count", 0)
 
 
+def _get_contributor_role_from_db(user_id: str, table_name: str) -> dict | None:
+    """Query DynamoDB for the user's contributor role record.
+
+    Args:
+        user_id: The authenticated user's ID.
+        table_name: DynamoDB table name (PROGRESS_TABLE).
+
+    Returns:
+        Dict with role, assigned_by, assigned_at, note or None if not set.
+    """
+    dynamodb = boto3.client("dynamodb")
+    response = dynamodb.get_item(
+        TableName=table_name,
+        Key={"PK": {"S": f"USER#{user_id}"}, "SK": {"S": "CONTRIBUTOR_ROLE"}},
+    )
+    item = response.get("Item")
+    if not item:
+        return None
+    return {
+        "role": item.get("role", {}).get("S", ""),
+        "assigned_by": item.get("assigned_by", {}).get("S", ""),
+        "assigned_at": item.get("assigned_at", {}).get("S", ""),
+        "note": item.get("note", {}).get("S", ""),
+    }
+
+
 @router.get("/user/profile")
 async def get_user_profile(
     user: dict = Depends(get_current_user),
@@ -168,6 +194,13 @@ async def get_user_profile(
         logger.error("DynamoDB error fetching progress for user %s: %s", user_id, exc)
         raise HTTPException(status_code=500, detail="Failed to fetch user profile")
 
+    # Fetch contributor role (if assigned by admin)
+    contributor_role = None
+    try:
+        contributor_role = _get_contributor_role_from_db(user_id, table_name)
+    except Exception as exc:
+        logger.warning("Failed to fetch contributor role for user %s: %s", user_id, exc)
+
     return {
         "user_id": profile["user_id"],
         "username": profile["username"],
@@ -177,6 +210,7 @@ async def get_user_profile(
         "last_login": profile["last_login"],
         "is_new_user": progress_count == 0,
         "total_completions": progress_count,
+        "contributor_role": contributor_role,
     }
 
 

--- a/backend/app/services/admin_service.py
+++ b/backend/app/services/admin_service.py
@@ -743,3 +743,103 @@ class AdminService:
             }
         except ClientError:
             return None
+
+    # ------------------------------------------------------------------
+    # Contributor role mapping
+    # ------------------------------------------------------------------
+
+    # Valid contributor roles
+    VALID_ROLES = {"contributor"}
+
+    def get_contributor_role(self, user_id: str) -> dict[str, Any] | None:
+        """Get a user's contributor role record.
+
+        Returns:
+            Dict with role, assigned_by, assigned_at, note or None if not set.
+        """
+        try:
+            response = self._client.get_item(
+                TableName=self._progress_table,
+                Key={
+                    "PK": {"S": f"USER#{user_id}"},
+                    "SK": {"S": "CONTRIBUTOR_ROLE"},
+                },
+            )
+            item = response.get("Item")
+            if not item:
+                return None
+            return {
+                "role": item.get("role", {}).get("S", ""),
+                "assigned_by": item.get("assigned_by", {}).get("S", ""),
+                "assigned_at": item.get("assigned_at", {}).get("S", ""),
+                "note": item.get("note", {}).get("S", ""),
+            }
+        except ClientError as e:
+            logger.error("Failed to get contributor role for %s: %s", user_id, e)
+            return None
+
+    def set_contributor_role(
+        self,
+        user_id: str,
+        role: str,
+        assigned_by: str,
+        note: str = "",
+    ) -> dict[str, Any]:
+        """Assign or update a contributor role for a user.
+
+        Args:
+            user_id: Target user ID.
+            role: One of VALID_ROLES.
+            assigned_by: Admin user ID performing the assignment.
+            note: Optional note about the assignment.
+
+        Returns:
+            The saved role record.
+
+        Raises:
+            ValueError: If role is not in VALID_ROLES.
+        """
+        if role not in self.VALID_ROLES:
+            raise ValueError(
+                f"Invalid role '{role}'. Must be one of: {', '.join(sorted(self.VALID_ROLES))}"
+            )
+
+        now = datetime.now(timezone.utc).isoformat()
+
+        item: dict[str, Any] = {
+            "PK": {"S": f"USER#{user_id}"},
+            "SK": {"S": "CONTRIBUTOR_ROLE"},
+            "role": {"S": role},
+            "assigned_by": {"S": assigned_by},
+            "assigned_at": {"S": now},
+        }
+        if note:
+            item["note"] = {"S": note}
+
+        self._client.put_item(TableName=self._progress_table, Item=item)
+
+        return {
+            "role": role,
+            "assigned_by": assigned_by,
+            "assigned_at": now,
+            "note": note,
+        }
+
+    def delete_contributor_role(self, user_id: str) -> bool:
+        """Remove a user's contributor role.
+
+        Returns:
+            True if deleted successfully, False on error.
+        """
+        try:
+            self._client.delete_item(
+                TableName=self._progress_table,
+                Key={
+                    "PK": {"S": f"USER#{user_id}"},
+                    "SK": {"S": "CONTRIBUTOR_ROLE"},
+                },
+            )
+            return True
+        except ClientError as e:
+            logger.error("Failed to delete contributor role for %s: %s", user_id, e)
+            return False

--- a/backend/app/services/admin_service.py
+++ b/backend/app/services/admin_service.py
@@ -843,3 +843,112 @@ class AdminService:
         except ClientError as e:
             logger.error("Failed to delete contributor role for %s: %s", user_id, e)
             return False
+
+    # ------------------------------------------------------------------
+    # Walkthrough access tier management
+    # ------------------------------------------------------------------
+
+    VALID_ACCESS_TIERS = {"FREE", "BUILDER"}
+
+    def get_walkthrough_access_tier(self, walkthrough_id: str) -> str:
+        """Get the access tier for a walkthrough.
+
+        Returns:
+            "FREE" or "BUILDER". Defaults to "FREE" if no record exists.
+        """
+        try:
+            response = self._client.get_item(
+                TableName=self._progress_table,
+                Key={
+                    "PK": {"S": "WALKTHROUGH_ACCESS"},
+                    "SK": {"S": f"WT#{walkthrough_id}"},
+                },
+            )
+            item = response.get("Item")
+            if not item:
+                return "FREE"
+            return item.get("access_tier", {}).get("S", "FREE")
+        except ClientError as e:
+            logger.error(
+                "Failed to get access tier for walkthrough %s: %s", walkthrough_id, e
+            )
+            return "FREE"
+
+    def set_walkthrough_access_tier(
+        self,
+        walkthrough_id: str,
+        access_tier: str,
+        set_by: str,
+    ) -> dict[str, Any]:
+        """Set the access tier for a walkthrough.
+
+        Args:
+            walkthrough_id: Walkthrough identifier.
+            access_tier: "FREE" or "BUILDER".
+            set_by: Admin user ID performing the action.
+
+        Returns:
+            The saved access tier record.
+
+        Raises:
+            ValueError: If access_tier is not valid.
+        """
+        if access_tier not in self.VALID_ACCESS_TIERS:
+            raise ValueError(
+                f"Invalid access tier '{access_tier}'. Must be one of: {', '.join(sorted(self.VALID_ACCESS_TIERS))}"
+            )
+
+        now = datetime.now(timezone.utc).isoformat()
+
+        item: dict[str, Any] = {
+            "PK": {"S": "WALKTHROUGH_ACCESS"},
+            "SK": {"S": f"WT#{walkthrough_id}"},
+            "access_tier": {"S": access_tier},
+            "set_by": {"S": set_by},
+            "updated_at": {"S": now},
+        }
+
+        self._client.put_item(TableName=self._progress_table, Item=item)
+
+        return {
+            "walkthrough_id": walkthrough_id,
+            "access_tier": access_tier,
+            "set_by": set_by,
+            "updated_at": now,
+        }
+
+    def get_all_walkthrough_access_tiers(self) -> dict[str, str]:
+        """Get access tiers for all walkthroughs that have explicit records.
+
+        Returns:
+            Dict mapping walkthrough_id -> access_tier for walkthroughs
+            with explicit tier records. Walkthroughs not in this dict
+            default to "FREE".
+        """
+        tiers: dict[str, str] = {}
+        last_key = None
+
+        while True:
+            params: dict[str, Any] = {
+                "TableName": self._progress_table,
+                "KeyConditionExpression": "PK = :pk",
+                "ExpressionAttributeValues": {
+                    ":pk": {"S": "WALKTHROUGH_ACCESS"},
+                },
+            }
+            if last_key:
+                params["ExclusiveStartKey"] = last_key
+
+            response = self._client.query(**params)
+            for item in response.get("Items", []):
+                sk = item.get("SK", {}).get("S", "")
+                if sk.startswith("WT#"):
+                    wt_id = sk[3:]
+                    tier = item.get("access_tier", {}).get("S", "FREE")
+                    tiers[wt_id] = tier
+
+            last_key = response.get("LastEvaluatedKey")
+            if not last_key:
+                break
+
+        return tiers

--- a/backend/app/services/broadcast_email.py
+++ b/backend/app/services/broadcast_email.py
@@ -9,7 +9,10 @@ but do not halt delivery to remaining users.
 import logging
 from typing import Any
 
-import markdown
+try:
+    import markdown
+except ImportError:
+    markdown = None  # type: ignore[assignment]
 
 from app.config import Settings
 from app.services.admin_service import AdminService
@@ -23,6 +26,9 @@ def _render_markdown_to_html(md_text: str) -> str:
 
     Supports headings, bold, italic, links, lists, and code blocks.
     """
+    if markdown is None:
+        # Fallback: return escaped text in paragraph tags
+        return f"<p>{md_text}</p>"
     return markdown.markdown(
         md_text,
         extensions=["extra", "nl2br", "sane_lists"],
@@ -67,13 +73,8 @@ def send_broadcast_emails(broadcast: dict[str, Any], settings: Settings) -> None
     # Render email template
     try:
         template = _jinja_env.get_template("broadcast_notification.html")
-        html_body = template.render(
-            title=title,
-            message_html=message_html,
-            link=link,
-        )
     except Exception as e:
-        logger.error("Broadcast email skipped: template render failed: %s", e)
+        logger.error("Broadcast email skipped: template load failed: %s", e)
         return
 
     # Fetch all users
@@ -84,23 +85,42 @@ def send_broadcast_emails(broadcast: dict[str, Any], settings: Settings) -> None
         logger.error("Broadcast email skipped: failed to fetch users: %s", e)
         return
 
-    # Filter to users with email addresses
-    users_with_email = [u for u in all_users if u.get("email", "").strip()]
+    # Filter to users with email addresses and deduplicate by email
+    seen_emails: set[str] = set()
+    unique_users = []
+    for user in all_users:
+        email = user.get("email", "").strip().lower()
+        if email and email not in seen_emails:
+            seen_emails.add(email)
+            unique_users.append(user)
 
-    if not users_with_email:
+    if not unique_users:
         logger.info("Broadcast email: no users with email addresses found")
         return
 
-    logger.info(
-        "Broadcast email: sending '%s' to %d users", title, len(users_with_email)
-    )
+    logger.info("Broadcast email: sending '%s' to %d users", title, len(unique_users))
 
-    # Send to each user
+    # Send to each user (personalized with username)
     success_count = 0
     fail_count = 0
 
-    for user in users_with_email:
+    for user in unique_users:
         email = user["email"].strip()
+        username = (
+            user.get("username", "").strip() or user.get("github_username", "").strip()
+        )
+
+        try:
+            html_body = template.render(
+                title=title,
+                message_html=message_html,
+                link=link,
+                username=username,
+            )
+        except Exception as e:
+            logger.warning("Broadcast email render failed for %s: %s", email, e)
+            fail_count += 1
+            continue
         try:
             sent = _send_email(
                 mailgun_domain=mailgun_domain,
@@ -121,5 +141,5 @@ def send_broadcast_emails(broadcast: dict[str, Any], settings: Settings) -> None
         "Broadcast email complete: %d sent, %d failed (total: %d)",
         success_count,
         fail_count,
-        len(users_with_email),
+        len(unique_users),
     )

--- a/backend/app/services/broadcast_email.py
+++ b/backend/app/services/broadcast_email.py
@@ -1,0 +1,125 @@
+"""Broadcast email delivery — sends broadcast notifications to all users.
+
+Called as a FastAPI BackgroundTask from the admin broadcast creation endpoint.
+Iterates all registered users with email addresses, renders the broadcast
+content (markdown → HTML), and sends via Mailgun. Failures are logged per-user
+but do not halt delivery to remaining users.
+"""
+
+import logging
+from typing import Any
+
+import markdown
+
+from app.config import Settings
+from app.services.admin_service import AdminService
+from app.services.email import _get_api_key, _send_email, _jinja_env
+
+logger = logging.getLogger(__name__)
+
+
+def _render_markdown_to_html(md_text: str) -> str:
+    """Convert markdown text to HTML.
+
+    Supports headings, bold, italic, links, lists, and code blocks.
+    """
+    return markdown.markdown(
+        md_text,
+        extensions=["extra", "nl2br", "sane_lists"],
+    )
+
+
+def send_broadcast_emails(broadcast: dict[str, Any], settings: Settings) -> None:
+    """Send a broadcast notification email to all users with email addresses.
+
+    This function is designed to be called as a BackgroundTask. It:
+    1. Fetches all registered users
+    2. Filters to those with non-empty email
+    3. Renders the broadcast markdown to HTML
+    4. Sends an email to each user via Mailgun
+
+    Args:
+        broadcast: Dict with title, message (markdown), link, created_by.
+        settings: Application settings instance.
+    """
+    mailgun_domain = settings.mailgun_domain
+    mailgun_param_name = settings.mailgun_param_name
+
+    if not mailgun_domain or not mailgun_param_name:
+        logger.error(
+            "Broadcast email skipped: Mailgun not configured (domain or param_name missing)"
+        )
+        return
+
+    # Get Mailgun API key
+    try:
+        api_key = _get_api_key(mailgun_param_name)
+    except Exception as e:
+        logger.error("Broadcast email skipped: failed to get Mailgun API key: %s", e)
+        return
+
+    # Render markdown to HTML
+    title = broadcast.get("title", "")
+    message_md = broadcast.get("message", "")
+    link = broadcast.get("link", "")
+    message_html = _render_markdown_to_html(message_md)
+
+    # Render email template
+    try:
+        template = _jinja_env.get_template("broadcast_notification.html")
+        html_body = template.render(
+            title=title,
+            message_html=message_html,
+            link=link,
+        )
+    except Exception as e:
+        logger.error("Broadcast email skipped: template render failed: %s", e)
+        return
+
+    # Fetch all users
+    try:
+        svc = AdminService(settings)
+        all_users = svc.get_all_registered_users()
+    except Exception as e:
+        logger.error("Broadcast email skipped: failed to fetch users: %s", e)
+        return
+
+    # Filter to users with email addresses
+    users_with_email = [u for u in all_users if u.get("email", "").strip()]
+
+    if not users_with_email:
+        logger.info("Broadcast email: no users with email addresses found")
+        return
+
+    logger.info(
+        "Broadcast email: sending '%s' to %d users", title, len(users_with_email)
+    )
+
+    # Send to each user
+    success_count = 0
+    fail_count = 0
+
+    for user in users_with_email:
+        email = user["email"].strip()
+        try:
+            sent = _send_email(
+                mailgun_domain=mailgun_domain,
+                api_key=api_key,
+                to_email=email,
+                subject=f"DSB: {title}",
+                html_body=html_body,
+            )
+            if sent:
+                success_count += 1
+            else:
+                fail_count += 1
+        except Exception as e:
+            logger.warning("Broadcast email failed for %s: %s", email, e)
+            fail_count += 1
+
+    logger.info(
+        "Broadcast email complete: %d sent, %d failed (total: %d)",
+        success_count,
+        fail_count,
+        len(users_with_email),
+    )

--- a/backend/app/services/broadcast_email.py
+++ b/backend/app/services/broadcast_email.py
@@ -1,8 +1,8 @@
-"""Broadcast email delivery — sends broadcast notifications to all users.
+"""Broadcast email delivery — sends broadcast notifications to all users via SES.
 
 Called as a FastAPI BackgroundTask from the admin broadcast creation endpoint.
 Iterates all registered users with email addresses, renders the broadcast
-content (markdown → HTML), and sends via Mailgun. Failures are logged per-user
+content (markdown to HTML), and sends via AWS SES. Failures are logged per-user
 but do not halt delivery to remaining users.
 """
 
@@ -16,7 +16,7 @@ except ImportError:
 
 from app.config import Settings
 from app.services.admin_service import AdminService
-from app.services.email import _get_api_key, _send_email, _jinja_env
+from app.services.email import _send_email, _jinja_env
 
 logger = logging.getLogger(__name__)
 
@@ -27,7 +27,6 @@ def _render_markdown_to_html(md_text: str) -> str:
     Supports headings, bold, italic, links, lists, and code blocks.
     """
     if markdown is None:
-        # Fallback: return escaped text in paragraph tags
         return f"<p>{md_text}</p>"
     return markdown.markdown(
         md_text,
@@ -40,37 +39,21 @@ def send_broadcast_emails(broadcast: dict[str, Any], settings: Settings) -> None
 
     This function is designed to be called as a BackgroundTask. It:
     1. Fetches all registered users
-    2. Filters to those with non-empty email
+    2. Filters to those with non-empty email, deduplicates
     3. Renders the broadcast markdown to HTML
-    4. Sends an email to each user via Mailgun
+    4. Sends an email to each user via AWS SES
 
     Args:
         broadcast: Dict with title, message (markdown), link, created_by.
         settings: Application settings instance.
     """
-    mailgun_domain = settings.mailgun_domain
-    mailgun_param_name = settings.mailgun_param_name
-
-    if not mailgun_domain or not mailgun_param_name:
-        logger.error(
-            "Broadcast email skipped: Mailgun not configured (domain or param_name missing)"
-        )
-        return
-
-    # Get Mailgun API key
-    try:
-        api_key = _get_api_key(mailgun_param_name)
-    except Exception as e:
-        logger.error("Broadcast email skipped: failed to get Mailgun API key: %s", e)
-        return
-
     # Render markdown to HTML
     title = broadcast.get("title", "")
     message_md = broadcast.get("message", "")
     link = broadcast.get("link", "")
     message_html = _render_markdown_to_html(message_md)
 
-    # Render email template
+    # Load email template
     try:
         template = _jinja_env.get_template("broadcast_notification.html")
     except Exception as e:
@@ -85,7 +68,7 @@ def send_broadcast_emails(broadcast: dict[str, Any], settings: Settings) -> None
         logger.error("Broadcast email skipped: failed to fetch users: %s", e)
         return
 
-    # Filter to users with email addresses and deduplicate by email
+    # Filter to users with email addresses and deduplicate
     seen_emails: set[str] = set()
     unique_users = []
     for user in all_users:
@@ -121,13 +104,14 @@ def send_broadcast_emails(broadcast: dict[str, Any], settings: Settings) -> None
             logger.warning("Broadcast email render failed for %s: %s", email, e)
             fail_count += 1
             continue
+
         try:
             sent = _send_email(
-                mailgun_domain=mailgun_domain,
-                api_key=api_key,
                 to_email=email,
                 subject=f"DSB: {title}",
                 html_body=html_body,
+                sender_email=settings.ses_sender_email,
+                ses_region=settings.ses_region,
             )
             if sent:
                 success_count += 1

--- a/backend/app/services/broadcast_service.py
+++ b/backend/app/services/broadcast_service.py
@@ -1,0 +1,293 @@
+"""Broadcast service — DynamoDB CRUD for admin broadcast notifications.
+
+Stores broadcasts in a dedicated BROADCASTS_TABLE with 90-day TTL.
+User dismissals are co-located in the same table for simple queries.
+
+DynamoDB Schema (BROADCASTS_TABLE):
+    Broadcast records:
+        PK: "BROADCAST"
+        SK: "MSG#{iso_timestamp}_{uuid_short}"
+    User dismissal records:
+        PK: "USER#{user_id}"
+        SK: "DISMISSED#{broadcast_id}"
+"""
+
+import logging
+import time
+import uuid
+from datetime import datetime, timezone
+from typing import Any
+
+import boto3
+from botocore.exceptions import ClientError
+
+from app.config import Settings
+
+logger = logging.getLogger(__name__)
+
+# 90 days in seconds
+BROADCAST_TTL_SECONDS = 90 * 24 * 60 * 60
+
+
+class BroadcastService:
+    """DynamoDB operations for broadcast notifications."""
+
+    def __init__(self, settings: Settings) -> None:
+        self._settings = settings
+        self._client = boto3.client("dynamodb")
+
+    @property
+    def _table_name(self) -> str:
+        return self._settings.broadcasts_table
+
+    # ------------------------------------------------------------------
+    # Broadcast CRUD
+    # ------------------------------------------------------------------
+
+    def create_broadcast(
+        self,
+        title: str,
+        message: str,
+        created_by: str,
+        link: str = "",
+    ) -> dict[str, Any]:
+        """Create a broadcast notification record.
+
+        Args:
+            title: Broadcast title (max 100 chars).
+            message: Markdown body (max 2000 chars).
+            created_by: Admin username.
+            link: Optional CTA URL.
+
+        Returns:
+            Created broadcast record dict.
+        """
+        now = datetime.now(timezone.utc)
+        created_at = now.isoformat()
+        uuid_short = uuid.uuid4().hex[:8]
+        broadcast_id = f"{created_at}_{uuid_short}"
+        ttl_value = int(time.time()) + BROADCAST_TTL_SECONDS
+
+        item: dict[str, Any] = {
+            "PK": {"S": "BROADCAST"},
+            "SK": {"S": f"MSG#{broadcast_id}"},
+            "broadcast_id": {"S": broadcast_id},
+            "title": {"S": title},
+            "message": {"S": message},
+            "link": {"S": link},
+            "created_by": {"S": created_by},
+            "created_at": {"S": created_at},
+            "ttl": {"N": str(ttl_value)},
+        }
+
+        self._client.put_item(TableName=self._table_name, Item=item)
+
+        return {
+            "broadcast_id": broadcast_id,
+            "title": title,
+            "message": message,
+            "link": link,
+            "created_by": created_by,
+            "created_at": created_at,
+        }
+
+    def get_all_broadcasts(self) -> list[dict[str, Any]]:
+        """Get all active broadcasts, sorted by created_at descending.
+
+        Returns:
+            List of broadcast dicts.
+        """
+        broadcasts: list[dict[str, Any]] = []
+        last_key = None
+
+        while True:
+            params: dict[str, Any] = {
+                "TableName": self._table_name,
+                "KeyConditionExpression": "PK = :pk",
+                "ExpressionAttributeValues": {":pk": {"S": "BROADCAST"}},
+            }
+            if last_key:
+                params["ExclusiveStartKey"] = last_key
+
+            response = self._client.query(**params)
+            for item in response.get("Items", []):
+                broadcasts.append(
+                    {
+                        "broadcast_id": item.get("broadcast_id", {}).get("S", ""),
+                        "title": item.get("title", {}).get("S", ""),
+                        "message": item.get("message", {}).get("S", ""),
+                        "link": item.get("link", {}).get("S", ""),
+                        "created_by": item.get("created_by", {}).get("S", ""),
+                        "created_at": item.get("created_at", {}).get("S", ""),
+                    }
+                )
+
+            last_key = response.get("LastEvaluatedKey")
+            if not last_key:
+                break
+
+        # Sort by created_at descending (newest first)
+        broadcasts.sort(key=lambda b: b["created_at"], reverse=True)
+        return broadcasts
+
+    def delete_broadcast(self, broadcast_id: str) -> bool:
+        """Delete a broadcast record.
+
+        Args:
+            broadcast_id: The broadcast_id to delete.
+
+        Returns:
+            True if deleted successfully.
+        """
+        try:
+            self._client.delete_item(
+                TableName=self._table_name,
+                Key={
+                    "PK": {"S": "BROADCAST"},
+                    "SK": {"S": f"MSG#{broadcast_id}"},
+                },
+            )
+            return True
+        except ClientError as e:
+            logger.error("Failed to delete broadcast %s: %s", broadcast_id, e)
+            return False
+
+    # ------------------------------------------------------------------
+    # User-facing: unread + dismiss
+    # ------------------------------------------------------------------
+
+    def get_unread_broadcasts(self, user_id: str) -> list[dict[str, Any]]:
+        """Get broadcasts the user has not dismissed.
+
+        Args:
+            user_id: Authenticated user ID.
+
+        Returns:
+            List of unread broadcast dicts, sorted oldest first (for modal stack).
+        """
+        # 1. Get all active broadcasts
+        all_broadcasts = self.get_all_broadcasts()
+        if not all_broadcasts:
+            return []
+
+        # 2. Get user's dismissed broadcast IDs
+        dismissed_ids = self._get_dismissed_ids(user_id)
+
+        # 3. Filter out dismissed ones
+        unread = [b for b in all_broadcasts if b["broadcast_id"] not in dismissed_ids]
+
+        # Sort oldest first for modal stack (chronological order)
+        unread.sort(key=lambda b: b["created_at"])
+        return unread
+
+    def dismiss_broadcast(self, user_id: str, broadcast_id: str) -> bool:
+        """Dismiss a single broadcast for a user.
+
+        Args:
+            user_id: Authenticated user ID.
+            broadcast_id: The broadcast to dismiss.
+
+        Returns:
+            True if successful.
+        """
+        now = datetime.now(timezone.utc).isoformat()
+        # Use same TTL as broadcasts so dismissals auto-clean
+        ttl_value = int(time.time()) + BROADCAST_TTL_SECONDS
+
+        try:
+            self._client.put_item(
+                TableName=self._table_name,
+                Item={
+                    "PK": {"S": f"USER#{user_id}"},
+                    "SK": {"S": f"DISMISSED#{broadcast_id}"},
+                    "dismissed_at": {"S": now},
+                    "ttl": {"N": str(ttl_value)},
+                },
+            )
+            return True
+        except ClientError as e:
+            logger.error(
+                "Failed to dismiss broadcast %s for user %s: %s",
+                broadcast_id,
+                user_id,
+                e,
+            )
+            return False
+
+    def dismiss_all_broadcasts(self, user_id: str, broadcast_ids: list[str]) -> bool:
+        """Dismiss multiple broadcasts for a user.
+
+        Args:
+            user_id: Authenticated user ID.
+            broadcast_ids: List of broadcast IDs to dismiss.
+
+        Returns:
+            True if all writes succeed.
+        """
+        if not broadcast_ids:
+            return True
+
+        now = datetime.now(timezone.utc).isoformat()
+        ttl_value = int(time.time()) + BROADCAST_TTL_SECONDS
+
+        # BatchWriteItem supports max 25 items per call
+        for i in range(0, len(broadcast_ids), 25):
+            batch = broadcast_ids[i : i + 25]
+            requests = [
+                {
+                    "PutRequest": {
+                        "Item": {
+                            "PK": {"S": f"USER#{user_id}"},
+                            "SK": {"S": f"DISMISSED#{bid}"},
+                            "dismissed_at": {"S": now},
+                            "ttl": {"N": str(ttl_value)},
+                        }
+                    }
+                }
+                for bid in batch
+            ]
+
+            try:
+                self._client.batch_write_item(RequestItems={self._table_name: requests})
+            except ClientError as e:
+                logger.error(
+                    "Failed to batch dismiss broadcasts for user %s: %s",
+                    user_id,
+                    e,
+                )
+                return False
+
+        return True
+
+    # ------------------------------------------------------------------
+    # Internal helpers
+    # ------------------------------------------------------------------
+
+    def _get_dismissed_ids(self, user_id: str) -> set[str]:
+        """Get set of broadcast IDs the user has dismissed."""
+        dismissed: set[str] = set()
+        last_key = None
+
+        while True:
+            params: dict[str, Any] = {
+                "TableName": self._table_name,
+                "KeyConditionExpression": "PK = :pk AND begins_with(SK, :sk_prefix)",
+                "ExpressionAttributeValues": {
+                    ":pk": {"S": f"USER#{user_id}"},
+                    ":sk_prefix": {"S": "DISMISSED#"},
+                },
+            }
+            if last_key:
+                params["ExclusiveStartKey"] = last_key
+
+            response = self._client.query(**params)
+            for item in response.get("Items", []):
+                sk = item.get("SK", {}).get("S", "")
+                if sk.startswith("DISMISSED#"):
+                    dismissed.add(sk[10:])  # len("DISMISSED#") == 10
+
+            last_key = response.get("LastEvaluatedKey")
+            if not last_key:
+                break
+
+        return dismissed

--- a/backend/app/services/email.py
+++ b/backend/app/services/email.py
@@ -1,7 +1,7 @@
-"""Email service — sends transactional emails via Mailgun API.
+"""Email service — sends transactional emails via AWS SES.
 
-Ported from backend/services/mailgun.py. Self-contained.
-Retrieves the Mailgun API key from AWS Parameter Store (SSM).
+Uses boto3 SES client to send HTML emails. No API keys needed — relies on
+the ECS task role's IAM permissions for ses:SendEmail.
 """
 
 import logging
@@ -9,9 +9,9 @@ from pathlib import Path
 from typing import Any
 
 import boto3
-import requests
 from botocore.exceptions import ClientError
 from jinja2 import Environment, FileSystemLoader
+from markupsafe import Markup
 
 from app.config import Settings
 from app.dependencies import get_settings
@@ -22,52 +22,53 @@ logger = logging.getLogger(__name__)
 _TEMPLATE_DIR = Path(__file__).parent.parent / "templates"
 _jinja_env = Environment(loader=FileSystemLoader(str(_TEMPLATE_DIR)), autoescape=True)
 
-# Module-level cache for the Mailgun API key
-_api_key_cache: dict[str, Any] = {"value": None}
-
-
-def _get_api_key(param_name: str) -> str:
-    """Retrieve Mailgun API key from SSM Parameter Store with caching."""
-    if _api_key_cache["value"] is not None:
-        return _api_key_cache["value"]
-
-    try:
-        ssm = boto3.client("ssm")
-        response = ssm.get_parameter(Name=param_name, WithDecryption=True)
-        value = response["Parameter"]["Value"]
-        _api_key_cache["value"] = value
-        return value
-    except (ClientError, KeyError) as e:
-        raise Exception(f"Failed to retrieve Mailgun API key: {e}")
-
 
 def _send_email(
-    mailgun_domain: str,
-    api_key: str,
     to_email: str,
     subject: str,
     html_body: str,
+    sender_email: str = "",
+    ses_region: str = "",
 ) -> bool:
-    """Send an email via Mailgun HTTP API."""
-    url = f"https://api.mailgun.net/v3/{mailgun_domain}/messages"
+    """Send an email via AWS SES.
+
+    Args:
+        to_email: Recipient email address.
+        subject: Email subject line.
+        html_body: Rendered HTML body.
+        sender_email: From address (defaults to settings if empty).
+        ses_region: AWS region for SES (defaults to settings if empty).
+
+    Returns:
+        True if sent successfully.
+    """
+    if not sender_email or not ses_region:
+        settings = get_settings()
+        sender_email = sender_email or settings.ses_sender_email
+        ses_region = ses_region or settings.ses_region
+
     try:
-        response = requests.post(
-            url,
-            auth=("api", api_key),
-            data={
-                "from": f"The DevSec Blueprint <noreply@{mailgun_domain}>",
-                "to": to_email,
-                "subject": subject,
-                "html": html_body,
+        ses = boto3.client("ses", region_name=ses_region)
+        ses.send_email(
+            Source=f"The DevSec Blueprint <{sender_email}>",
+            Destination={"ToAddresses": [to_email]},
+            Message={
+                "Subject": {"Data": subject, "Charset": "UTF-8"},
+                "Body": {
+                    "Html": {"Data": html_body, "Charset": "UTF-8"},
+                },
             },
-            timeout=10,
         )
-        if response.status_code == 200:
-            return True
-        logger.error("Mailgun API error: %s - %s", response.status_code, response.text)
+        return True
+    except ClientError as e:
+        logger.error(
+            "SES send failed for %s: %s",
+            to_email,
+            e.response["Error"]["Message"],
+        )
         return False
     except Exception as e:
-        logger.error("Failed to send email: %s", e)
+        logger.error("Failed to send email to %s: %s", to_email, e)
         return False
 
 
@@ -87,15 +88,7 @@ def send_capstone_notification(
     """
     try:
         settings = get_settings()
-        mailgun_domain = settings.mailgun_domain
-        mailgun_param_name = settings.mailgun_param_name
         to_email = settings.testimonial_notify_email
-
-        if not mailgun_domain or not mailgun_param_name:
-            logger.error("Mailgun not configured (domain or param_name missing)")
-            return False
-
-        api_key = _get_api_key(mailgun_param_name)
 
         template = _jinja_env.get_template("capstone_submission_notification.html")
         html_body = template.render(
@@ -105,9 +98,7 @@ def send_capstone_notification(
             submitted_at=submitted_at,
         )
 
-        return _send_email(
-            mailgun_domain, api_key, to_email, "New Capstone Submission", html_body
-        )
+        return _send_email(to_email, "New Capstone Submission", html_body)
 
     except Exception as e:
         logger.error("Failed to send capstone notification: %s", e)
@@ -124,15 +115,7 @@ def send_testimonial_notification(
     """
     try:
         settings = get_settings()
-        mailgun_domain = settings.mailgun_domain
-        mailgun_param_name = settings.mailgun_param_name
         to_email = settings.testimonial_notify_email
-
-        if not mailgun_domain or not mailgun_param_name:
-            logger.error("Mailgun not configured")
-            return False
-
-        api_key = _get_api_key(mailgun_param_name)
 
         template = _jinja_env.get_template("testimonial_notification.html")
         html_body = template.render(
@@ -141,9 +124,7 @@ def send_testimonial_notification(
             quote=quote,
         )
 
-        return _send_email(
-            mailgun_domain, api_key, to_email, "New Testimonial Submission", html_body
-        )
+        return _send_email(to_email, "New Testimonial Submission", html_body)
 
     except Exception as e:
         logger.error("Failed to send testimonial notification: %s", e)
@@ -159,26 +140,21 @@ def send_review_notification_to_learner(
         True if sent successfully.
     """
     try:
-        settings = get_settings()
-        mailgun_domain = settings.mailgun_domain
-        mailgun_param_name = settings.mailgun_param_name
-
-        if not mailgun_domain or not mailgun_param_name or not email:
-            logger.error("Mailgun not configured or email missing")
+        if not email:
+            logger.error("Email missing for review notification")
             return False
-
-        api_key = _get_api_key(mailgun_param_name)
 
         # Convert markdown feedback to HTML
         feedback_html = ""
         if feedback:
-            import markdown as md
+            try:
+                import markdown as md
 
-            feedback_html = md.markdown(
-                feedback, extensions=["fenced_code", "tables", "nl2br"]
-            )
-
-        from markupsafe import Markup
+                feedback_html = md.markdown(
+                    feedback, extensions=["fenced_code", "tables", "nl2br"]
+                )
+            except ImportError:
+                feedback_html = f"<p>{feedback}</p>"
 
         template = _jinja_env.get_template("capstone_review_notification.html")
 
@@ -211,9 +187,7 @@ def send_review_notification_to_learner(
             platform_url="https://devsecblueprint.com",
         )
 
-        return _send_email(
-            mailgun_domain, api_key, email, "Your Capstone Feedback is Ready", html_body
-        )
+        return _send_email(email, "Your Capstone Feedback is Ready", html_body)
 
     except Exception as e:
         logger.error("Failed to send review notification: %s", e)
@@ -227,15 +201,9 @@ def send_welcome_email(username: str, email: str) -> bool:
         True if sent successfully.
     """
     try:
-        settings = get_settings()
-        mailgun_domain = settings.mailgun_domain
-        mailgun_param_name = settings.mailgun_param_name
-
-        if not mailgun_domain or not mailgun_param_name or not email:
-            logger.error("Mailgun not configured or email missing")
+        if not email:
+            logger.error("Email missing for welcome email")
             return False
-
-        api_key = _get_api_key(mailgun_param_name)
 
         template = _jinja_env.get_template("welcome_email.html")
         html_body = template.render(
@@ -243,13 +211,7 @@ def send_welcome_email(username: str, email: str) -> bool:
             platform_url="https://devsecblueprint.com",
         )
 
-        return _send_email(
-            mailgun_domain,
-            api_key,
-            email,
-            "Welcome to The DevSec Blueprint!",
-            html_body,
-        )
+        return _send_email(email, "Welcome to The DevSec Blueprint!", html_body)
 
     except Exception as e:
         logger.error("Failed to send welcome email: %s", e)
@@ -264,25 +226,16 @@ def send_subscription_expired_email(
     Args:
         username: User's display name.
         email: User's email address.
-        previous_tier: The tier they were on before expiration (e.g. "EXPLORER").
+        previous_tier: The tier they were on before expiration.
 
     Returns:
         True if sent successfully.
     """
     try:
-        settings = get_settings()
-        mailgun_domain = settings.mailgun_domain
-        mailgun_param_name = settings.mailgun_param_name
-
-        if not mailgun_domain or not mailgun_param_name or not email:
-            logger.warning(
-                "Mailgun not configured or email missing, skipping expiration email"
-            )
+        if not email:
+            logger.warning("Email missing, skipping expiration email")
             return False
 
-        api_key = _get_api_key(mailgun_param_name)
-
-        # Format tier name for display
         tier_display = (
             previous_tier.replace("_", " ").title() if previous_tier else "Premium"
         )
@@ -295,11 +248,7 @@ def send_subscription_expired_email(
         )
 
         return _send_email(
-            mailgun_domain,
-            api_key,
-            email,
-            "Your DevSec Blueprint Subscription Has Ended",
-            html_body,
+            email, "Your DevSec Blueprint Subscription Has Ended", html_body
         )
 
     except Exception as e:
@@ -313,23 +262,15 @@ def send_subscription_welcome_email(username: str, email: str, tier: str) -> boo
     Args:
         username: User's display name.
         email: User's email address.
-        tier: The tier they subscribed to (e.g. "EXPLORER").
+        tier: The tier they subscribed to.
 
     Returns:
         True if sent successfully.
     """
     try:
-        settings = get_settings()
-        mailgun_domain = settings.mailgun_domain
-        mailgun_param_name = settings.mailgun_param_name
-
-        if not mailgun_domain or not mailgun_param_name or not email:
-            logger.warning(
-                "Mailgun not configured or email missing, skipping subscription welcome"
-            )
+        if not email:
+            logger.warning("Email missing, skipping subscription welcome")
             return False
-
-        api_key = _get_api_key(mailgun_param_name)
 
         tier_display = tier.replace("_", " ").title() if tier else "Premium"
 
@@ -340,13 +281,7 @@ def send_subscription_welcome_email(username: str, email: str, tier: str) -> boo
             platform_url="https://devsecblueprint.com",
         )
 
-        return _send_email(
-            mailgun_domain,
-            api_key,
-            email,
-            f"Welcome to DSB {tier_display}! 🎉",
-            html_body,
-        )
+        return _send_email(email, f"Welcome to DSB {tier_display}!", html_body)
 
     except Exception as e:
         logger.error("Failed to send subscription welcome email: %s", e)

--- a/backend/app/templates/broadcast_notification.html
+++ b/backend/app/templates/broadcast_notification.html
@@ -1,0 +1,58 @@
+<!DOCTYPE html>
+<html lang="en">
+<head>
+  <meta charset="UTF-8">
+  <meta name="viewport" content="width=device-width, initial-scale=1.0">
+  <title>{{ title }}</title>
+</head>
+<body style="margin: 0; padding: 0; background-color: #f4f4f5; font-family: -apple-system, BlinkMacSystemFont, 'Segoe UI', Roboto, 'Helvetica Neue', Arial, sans-serif;">
+  <table role="presentation" width="100%" cellpadding="0" cellspacing="0" bgcolor="#f4f4f5" style="background-color: #f4f4f5; padding: 32px 16px;">
+    <tr>
+      <td align="center">
+        <table role="presentation" cellpadding="0" cellspacing="0" bgcolor="#ffffff" style="width: 100%; max-width: 600px; background-color: #ffffff; border-radius: 10px; overflow: hidden; box-shadow: 0 1px 4px rgba(0, 0, 0, 0.1);">
+          <!-- Header -->
+          <tr>
+            <td style="padding: 28px 32px 20px 32px; text-align: center;">
+              <img src="https://devsecblueprint.com/light_mode_logo.svg" alt="The DevSec Blueprint" width="180" style="max-width: 180px; height: auto;">
+            </td>
+          </tr>
+          <!-- Title bar -->
+          <tr>
+            <td bgcolor="#ffbe00" style="background-color: #ffbe00; padding: 16px 32px; text-align: center;">
+              <span style="font-size: 20px; font-weight: 700; color: #18181b;">📢 {{ title }}</span>
+            </td>
+          </tr>
+          <!-- Body -->
+          <tr>
+            <td style="padding: 32px;">
+              <div style="font-size: 15px; color: #27272a; line-height: 1.7;">
+                {{ message_html }}
+              </div>
+              {% if link %}
+              <!-- CTA Button -->
+              <table role="presentation" cellpadding="0" cellspacing="0" style="margin: 28px auto 16px auto;">
+                <tr>
+                  <td align="center" bgcolor="#ffbe00" style="background-color: #ffbe00; border-radius: 6px;">
+                    <a href="{{ link }}" style="display: inline-block; padding: 13px 26px; font-size: 15px; font-weight: 700; color: #18181b; text-decoration: none;" target="_blank" rel="noopener noreferrer">
+                      Learn More
+                    </a>
+                  </td>
+                </tr>
+              </table>
+              {% endif %}
+            </td>
+          </tr>
+          <!-- Footer -->
+          <tr>
+            <td bgcolor="#fafafa" style="background-color: #fafafa; padding: 20px 32px; border-top: 1px solid #e4e4e7; text-align: center;">
+              <p style="margin: 0; font-size: 12px; color: #71717a; line-height: 1.5;">
+                The DevSec Blueprint — DevSecOps and Cloud Security mastery, one project at a time.
+              </p>
+            </td>
+          </tr>
+        </table>
+      </td>
+    </tr>
+  </table>
+</body>
+</html>

--- a/backend/app/templates/broadcast_notification.html
+++ b/backend/app/templates/broadcast_notification.html
@@ -19,22 +19,55 @@
           <!-- Title bar -->
           <tr>
             <td bgcolor="#ffbe00" style="background-color: #ffbe00; padding: 16px 32px; text-align: center;">
-              <span style="font-size: 20px; font-weight: 700; color: #18181b;">📢 {{ title }}</span>
+              <span style="font-size: 20px; font-weight: 700; color: #18181b;">{{ title }}</span>
             </td>
           </tr>
           <!-- Body -->
           <tr>
             <td style="padding: 32px;">
+              <!-- Greeting -->
+              {% if username %}
+              <p style="margin: 0 0 20px 0; font-size: 16px; color: #18181b; line-height: 1.6;">
+                Hi <strong>{{ username }}</strong>,
+              </p>
+              {% endif %}
+
+              <!-- Markdown content with inline styles for email rendering -->
               <div style="font-size: 15px; color: #27272a; line-height: 1.7;">
-                {{ message_html }}
+                <!--[if mso]><style>h1,h2,h3{margin:16px 0 8px 0!important}p{margin:0 0 12px 0!important}ul,ol{margin:0 0 16px 0!important;padding-left:24px!important}</style><![endif]-->
+                <style>
+                  .broadcast-body h1 { font-size: 22px; font-weight: 700; color: #18181b; margin: 20px 0 10px 0; line-height: 1.3; }
+                  .broadcast-body h2 { font-size: 18px; font-weight: 700; color: #18181b; margin: 18px 0 8px 0; line-height: 1.3; }
+                  .broadcast-body h3 { font-size: 16px; font-weight: 600; color: #27272a; margin: 16px 0 6px 0; line-height: 1.4; }
+                  .broadcast-body p { margin: 0 0 14px 0; font-size: 15px; color: #27272a; line-height: 1.7; }
+                  .broadcast-body ul, .broadcast-body ol { margin: 0 0 16px 0; padding-left: 24px; font-size: 15px; color: #27272a; line-height: 1.8; }
+                  .broadcast-body li { margin-bottom: 6px; }
+                  .broadcast-body strong { color: #18181b; }
+                  .broadcast-body a { color: #b45309; text-decoration: underline; }
+                  .broadcast-body code { background-color: #f4f4f5; padding: 2px 6px; border-radius: 4px; font-size: 13px; font-family: 'SF Mono', Monaco, 'Cascadia Code', monospace; color: #18181b; }
+                  .broadcast-body pre { background-color: #f4f4f5; padding: 14px 18px; border-radius: 6px; overflow-x: auto; margin: 0 0 16px 0; }
+                  .broadcast-body pre code { background: none; padding: 0; font-size: 13px; }
+                  .broadcast-body blockquote { border-left: 3px solid #ffbe00; margin: 0 0 16px 0; padding: 8px 16px; color: #52525b; }
+                </style>
+                <div class="broadcast-body">
+                  {{ message_html | safe }}
+                </div>
               </div>
+
               {% if link %}
+              <!-- Divider -->
+              <table role="presentation" width="100%" cellpadding="0" cellspacing="0" style="margin: 24px 0;">
+                <tr>
+                  <td style="border-top: 1px solid #e4e4e7;"></td>
+                </tr>
+              </table>
+
               <!-- CTA Button -->
-              <table role="presentation" cellpadding="0" cellspacing="0" style="margin: 28px auto 16px auto;">
+              <table role="presentation" cellpadding="0" cellspacing="0" style="margin: 0 auto 8px auto;">
                 <tr>
                   <td align="center" bgcolor="#ffbe00" style="background-color: #ffbe00; border-radius: 6px;">
                     <a href="{{ link }}" style="display: inline-block; padding: 13px 26px; font-size: 15px; font-weight: 700; color: #18181b; text-decoration: none;" target="_blank" rel="noopener noreferrer">
-                      Learn More
+                      View on Platform
                     </a>
                   </td>
                 </tr>
@@ -45,8 +78,11 @@
           <!-- Footer -->
           <tr>
             <td bgcolor="#fafafa" style="background-color: #fafafa; padding: 20px 32px; border-top: 1px solid #e4e4e7; text-align: center;">
-              <p style="margin: 0; font-size: 12px; color: #71717a; line-height: 1.5;">
+              <p style="margin: 0 0 8px 0; font-size: 12px; color: #71717a; line-height: 1.5;">
                 The DevSec Blueprint — DevSecOps and Cloud Security mastery, one project at a time.
+              </p>
+              <p style="margin: 0; font-size: 11px; color: #a1a1aa; line-height: 1.5;">
+                You're receiving this because you have an account on The DevSec Blueprint.
               </p>
             </td>
           </tr>

--- a/backend/requirements.txt
+++ b/backend/requirements.txt
@@ -6,6 +6,5 @@ httpx==0.28.1
 python-jose[cryptography]==3.3.0
 stripe==12.1.0
 apscheduler==3.11.0
-requests==2.32.3
 jinja2==3.1.6
 markdown==3.7

--- a/backend/requirements.txt
+++ b/backend/requirements.txt
@@ -8,3 +8,4 @@ stripe==12.1.0
 apscheduler==3.11.0
 requests==2.32.3
 jinja2==3.1.6
+markdown==3.7

--- a/frontend/app/admin/page.tsx
+++ b/frontend/app/admin/page.tsx
@@ -12,6 +12,8 @@ import { apiClient } from '@/lib/api';
 import { CapstoneSubmissions } from '@/components/admin/CapstoneSubmissions';
 import { UserList } from '@/components/admin/UserList';
 import { WalkthroughStatistics } from '@/components/admin/WalkthroughStatistics';
+import { WalkthroughAccessTiers } from '@/components/admin/WalkthroughAccessTiers';
+import { BroadcastManagement } from '@/components/admin/BroadcastManagement';
 import { ActiveSessionsModal } from '@/components/admin/ActiveSessionsModal';
 import { TestimonialModeration } from '@/components/admin/TestimonialModeration';
 
@@ -494,6 +496,17 @@ export default function AdminDashboardPage() {
                 )}
               </Card>
 
+              {/* Broadcast Notifications - Full Width */}
+              <Card padding="lg" className="lg:col-span-2">
+                {adminSectionsLoading ? (
+                  <div className="flex items-center justify-center py-12">
+                    <Spinner size="lg" />
+                  </div>
+                ) : (
+                  <BroadcastManagement />
+                )}
+              </Card>
+
               {/* Testimonial Moderation - Full Width */}
               <Card padding="lg" className="lg:col-span-2">
                 {adminSectionsLoading ? (
@@ -535,6 +548,17 @@ export default function AdminDashboardPage() {
                   </div>
                 ) : (
                   <WalkthroughStatistics />
+                )}
+              </Card>
+
+              {/* Walkthrough Access Tiers - Full Width */}
+              <Card padding="lg" className="lg:col-span-2">
+                {adminSectionsLoading ? (
+                  <div className="flex items-center justify-center py-12">
+                    <Spinner size="lg" />
+                  </div>
+                ) : (
+                  <WalkthroughAccessTiers />
                 )}
               </Card>
 

--- a/frontend/app/dashboard/page.tsx
+++ b/frontend/app/dashboard/page.tsx
@@ -25,7 +25,8 @@ import { useAllProgress } from '@/lib/hooks/useAllProgress';
 import { useLastActiveLesson } from '@/lib/hooks/useLastActiveLesson';
 import { getAllCourses } from '@/lib/course-utils';
 import { apiClient } from '@/lib/api';
-import type { ContributorRole } from '@/lib/types';
+import type { ContributorRole, BroadcastItem } from '@/lib/types';
+import { BroadcastModal } from '@/components/BroadcastModal';
 
 export default function DashboardPage() {
   const { userId, avatarUrl, username } = useAuth();
@@ -37,6 +38,8 @@ export default function DashboardPage() {
   const [showWelcomeModal, setShowWelcomeModal] = useState(false);
   const [hasCheckedProfile, setHasCheckedProfile] = useState(false);
   const [contributorRole, setContributorRole] = useState<ContributorRole | null>(null);
+  const [unreadBroadcasts, setUnreadBroadcasts] = useState<BroadcastItem[]>([]);
+  const [showBroadcastModal, setShowBroadcastModal] = useState(false);
 
   // Debug logging for modal state
   useEffect(() => {
@@ -87,6 +90,23 @@ export default function DashboardPage() {
     // Mark as seen in session storage so it doesn't show again during this session
     sessionStorage.setItem('hasSeenWelcome', 'true');
   };
+
+  // Fetch unread broadcasts — show modal only when welcome modal is not showing
+  useEffect(() => {
+    const fetchBroadcasts = async () => {
+      if (!userId || showWelcomeModal) return;
+      try {
+        const { data } = await apiClient.getUnreadBroadcasts();
+        if (data?.broadcasts && data.broadcasts.length > 0) {
+          setUnreadBroadcasts(data.broadcasts);
+          setShowBroadcastModal(true);
+        }
+      } catch (err) {
+        console.error('Failed to fetch broadcasts:', err);
+      }
+    };
+    fetchBroadcasts();
+  }, [userId, showWelcomeModal]);
 
   // Prepare stats for DashboardStats component
   const stats = [
@@ -191,6 +211,17 @@ export default function DashboardPage() {
         <BadgeNotification
           badge={newlyEarnedBadges[0]}
           onClose={clearNewBadge}
+        />
+      )}
+
+      {/* Broadcast Modal */}
+      {showBroadcastModal && unreadBroadcasts.length > 0 && (
+        <BroadcastModal
+          broadcasts={unreadBroadcasts}
+          onAllDismissed={() => {
+            setShowBroadcastModal(false);
+            setUnreadBroadcasts([]);
+          }}
         />
       )}
 

--- a/frontend/app/dashboard/page.tsx
+++ b/frontend/app/dashboard/page.tsx
@@ -25,6 +25,7 @@ import { useAllProgress } from '@/lib/hooks/useAllProgress';
 import { useLastActiveLesson } from '@/lib/hooks/useLastActiveLesson';
 import { getAllCourses } from '@/lib/course-utils';
 import { apiClient } from '@/lib/api';
+import type { ContributorRole } from '@/lib/types';
 
 export default function DashboardPage() {
   const { userId, avatarUrl, username } = useAuth();
@@ -35,6 +36,7 @@ export default function DashboardPage() {
   const { pageSlug: lastActivePageSlug, isLoading: lastActiveLessonLoading } = useLastActiveLesson();
   const [showWelcomeModal, setShowWelcomeModal] = useState(false);
   const [hasCheckedProfile, setHasCheckedProfile] = useState(false);
+  const [contributorRole, setContributorRole] = useState<ContributorRole | null>(null);
 
   // Debug logging for modal state
   useEffect(() => {
@@ -64,6 +66,11 @@ export default function DashboardPage() {
           }
         } else {
           console.log('[WelcomeModal] User is not new or data missing');
+        }
+
+        // Store contributor role if present
+        if (data?.contributor_role) {
+          setContributorRole(data.contributor_role);
         }
       } catch (err) {
         console.error('[WelcomeModal] Failed to fetch user profile:', err);
@@ -292,6 +299,16 @@ export default function DashboardPage() {
                     day: 'numeric' 
                   })}
                 </p>
+                {contributorRole && (
+                  <div className="mt-2">
+                    <span className="inline-flex items-center px-3 py-1 rounded-full text-xs font-semibold bg-purple-100 text-purple-800 dark:bg-purple-900/30 dark:text-purple-400">
+                      <svg className="w-3.5 h-3.5 mr-1.5" fill="none" stroke="currentColor" viewBox="0 0 24 24" aria-hidden="true">
+                        <path strokeLinecap="round" strokeLinejoin="round" strokeWidth={2} d="M5 3v4M3 5h4M6 17v4m-2-2h4m5-16l2.286 6.857L21 12l-5.714 2.143L13 21l-2.286-6.857L5 12l5.714-2.143L13 3z" />
+                      </svg>
+                      Contributor
+                    </span>
+                  </div>
+                )}
               </div>
             </div>
           </div>

--- a/frontend/app/walkthroughs/page.tsx
+++ b/frontend/app/walkthroughs/page.tsx
@@ -18,10 +18,13 @@ import { NavbarWithAuth } from '@/components/layout/NavbarWithAuth';
 import { ErrorBoundary } from '@/components/ErrorBoundary';
 import { WalkthroughBrowser } from '@/components/WalkthroughBrowser';
 import { getWalkthroughsWithProgress } from '@/lib/walkthrough-client';
+import { apiClient } from '@/lib/api';
 import type { WalkthroughWithProgress } from '@/lib/types';
 
 export default function WalkthroughsPage() {
   const [walkthroughs, setWalkthroughs] = useState<WalkthroughWithProgress[]>([]);
+  const [lockedWalkthroughs, setLockedWalkthroughs] = useState<Record<string, string>>({});
+  const [membershipTier, setMembershipTier] = useState<string>('FREE');
   const [isLoading, setIsLoading] = useState(true);
   const [error, setError] = useState<string | null>(null);
 
@@ -34,9 +37,22 @@ export default function WalkthroughsPage() {
     setError(null);
 
     try {
-      // Load walkthroughs from local content with progress data from backend
-      const walkthroughsData = await getWalkthroughsWithProgress();
+      // Load walkthroughs, access tiers, and membership tier in parallel
+      const [walkthroughsData, tiersResponse, subResponse] = await Promise.all([
+        getWalkthroughsWithProgress(),
+        apiClient.getWalkthroughAccessTiers(),
+        apiClient.get<{ membership_tier: string }>('/api/stripe/subscription'),
+      ]);
+
       setWalkthroughs(walkthroughsData);
+
+      if (tiersResponse.data?.access_tiers) {
+        setLockedWalkthroughs(tiersResponse.data.access_tiers);
+      }
+
+      if (subResponse.data?.membership_tier) {
+        setMembershipTier(subResponse.data.membership_tier);
+      }
     } catch (err) {
       console.error('Failed to load walkthroughs:', err);
       setError(err instanceof Error ? err.message : 'Failed to load walkthroughs');
@@ -83,7 +99,11 @@ export default function WalkthroughsPage() {
                   </div>
                 </div>
               ) : (
-                <WalkthroughBrowser initialWalkthroughs={walkthroughs} />
+                <WalkthroughBrowser
+                  initialWalkthroughs={walkthroughs}
+                  lockedWalkthroughs={lockedWalkthroughs}
+                  membershipTier={membershipTier}
+                />
               )}
             </div>
           </main>

--- a/frontend/components/BroadcastModal.tsx
+++ b/frontend/components/BroadcastModal.tsx
@@ -1,0 +1,257 @@
+'use client';
+
+import { useState, useEffect, useRef, useCallback } from 'react';
+import { apiClient } from '@/lib/api';
+import { Card } from '@/components/ui/Card';
+import { Button } from '@/components/ui/Button';
+import MarkdownRenderer from '@/components/MarkdownRenderer';
+import type { BroadcastItem } from '@/lib/types';
+import { format } from 'date-fns';
+
+interface BroadcastModalProps {
+  broadcasts: BroadcastItem[];
+  onAllDismissed: () => void;
+}
+
+/**
+ * BroadcastModal — stacked modal showing unread broadcast notifications.
+ *
+ * Displays broadcasts one at a time (oldest first) with:
+ * - Title and date
+ * - Markdown body rendered as HTML
+ * - Optional CTA link button
+ * - Dismiss / Dismiss All / Next navigation
+ *
+ * Accessible: focus trap, escape to close, aria-modal.
+ */
+export function BroadcastModal({ broadcasts: initialBroadcasts, onAllDismissed }: BroadcastModalProps) {
+  const [broadcasts, setBroadcasts] = useState<BroadcastItem[]>(initialBroadcasts);
+  const [currentIndex, setCurrentIndex] = useState(0);
+  const [isVisible, setIsVisible] = useState(false);
+  const [isDismissing, setIsDismissing] = useState(false);
+  const modalRef = useRef<HTMLDivElement>(null);
+  const previousFocusRef = useRef<HTMLElement | null>(null);
+
+  // Animate in
+  useEffect(() => {
+    setTimeout(() => setIsVisible(true), 10);
+  }, []);
+
+  // Focus management
+  useEffect(() => {
+    previousFocusRef.current = document.activeElement as HTMLElement;
+    const firstButton = modalRef.current?.querySelector<HTMLElement>('button');
+    firstButton?.focus();
+    return () => {
+      previousFocusRef.current?.focus();
+    };
+  }, []);
+
+  // Prevent body scroll
+  useEffect(() => {
+    const original = document.body.style.overflow;
+    document.body.style.overflow = 'hidden';
+    return () => {
+      document.body.style.overflow = original;
+    };
+  }, []);
+
+  // Keyboard handling
+  const handleKeyDown = useCallback(
+    (e: KeyboardEvent) => {
+      if (e.key === 'Escape') {
+        handleDismissCurrent();
+      }
+    },
+    // eslint-disable-next-line react-hooks/exhaustive-deps
+    [currentIndex, broadcasts]
+  );
+
+  useEffect(() => {
+    document.addEventListener('keydown', handleKeyDown);
+    return () => document.removeEventListener('keydown', handleKeyDown);
+  }, [handleKeyDown]);
+
+  const current = broadcasts[currentIndex];
+  const total = broadcasts.length;
+
+  const handleDismissCurrent = async () => {
+    if (!current || isDismissing) return;
+    setIsDismissing(true);
+
+    try {
+      await apiClient.dismissBroadcast(current.broadcast_id);
+    } catch (err) {
+      console.error('Failed to dismiss broadcast:', err);
+    }
+
+    const remaining = broadcasts.filter((_, i) => i !== currentIndex);
+    if (remaining.length === 0) {
+      onAllDismissed();
+    } else {
+      setBroadcasts(remaining);
+      setCurrentIndex(Math.min(currentIndex, remaining.length - 1));
+    }
+    setIsDismissing(false);
+  };
+
+  const handleDismissAll = async () => {
+    if (isDismissing) return;
+    setIsDismissing(true);
+
+    try {
+      await apiClient.dismissAllBroadcasts();
+    } catch (err) {
+      console.error('Failed to dismiss all broadcasts:', err);
+    }
+
+    onAllDismissed();
+  };
+
+  const handleNext = () => {
+    if (currentIndex < total - 1) {
+      setCurrentIndex(currentIndex + 1);
+    }
+  };
+
+  const handlePrev = () => {
+    if (currentIndex > 0) {
+      setCurrentIndex(currentIndex - 1);
+    }
+  };
+
+  const formatDate = (dateStr: string) => {
+    try {
+      return format(new Date(dateStr), 'MMM d, yyyy');
+    } catch {
+      return '';
+    }
+  };
+
+  if (!current) return null;
+
+  return (
+    <div
+      className={`fixed inset-0 z-50 flex items-center justify-center p-4 transition-opacity duration-300 ${
+        isVisible ? 'opacity-100' : 'opacity-0'
+      }`}
+      role="dialog"
+      aria-modal="true"
+      aria-labelledby="broadcast-modal-title"
+    >
+      {/* Backdrop */}
+      <div className="absolute inset-0 bg-black/60 backdrop-blur-sm" />
+
+      {/* Modal */}
+      <div
+        ref={modalRef}
+        className={`relative w-full max-w-lg max-h-[80vh] flex flex-col transform transition-all duration-300 ${
+          isVisible ? 'scale-100 translate-y-0' : 'scale-95 translate-y-4'
+        }`}
+      >
+        <Card padding="lg">
+          {/* Header */}
+          <div className="flex items-center justify-between mb-4">
+            <div className="flex items-center space-x-2">
+              <span className="text-xl" aria-hidden="true">📢</span>
+              <span className="text-sm text-gray-500 dark:text-gray-400 font-medium">
+                {currentIndex + 1} of {total}
+              </span>
+            </div>
+            <button
+              onClick={handleDismissCurrent}
+              className="text-gray-400 hover:text-gray-600 dark:hover:text-gray-300 transition-colors"
+              aria-label="Dismiss this announcement"
+              disabled={isDismissing}
+            >
+              <svg className="w-5 h-5" fill="none" stroke="currentColor" viewBox="0 0 24 24">
+                <path strokeLinecap="round" strokeLinejoin="round" strokeWidth={2} d="M6 18L18 6M6 6l12 12" />
+              </svg>
+            </button>
+          </div>
+
+          {/* Title */}
+          <h2
+            id="broadcast-modal-title"
+            className="text-xl font-bold text-gray-900 dark:text-gray-100 mb-1"
+          >
+            {current.title}
+          </h2>
+          <p className="text-xs text-gray-500 dark:text-gray-400 mb-4">
+            {formatDate(current.created_at)}
+          </p>
+
+          {/* Body — scrollable */}
+          <div className="overflow-y-auto max-h-[40vh] mb-4 pr-1">
+            <div className="prose prose-sm dark:prose-invert max-w-none">
+              <MarkdownRenderer markdown={current.message} />
+            </div>
+          </div>
+
+          {/* CTA Link */}
+          {current.link && (
+            <div className="mb-4">
+              <a
+                href={current.link}
+                className="inline-flex items-center px-4 py-2 bg-amber-500 hover:bg-amber-600 text-gray-900 font-semibold text-sm rounded-lg transition-colors"
+                target={current.link.startsWith('http') ? '_blank' : undefined}
+                rel={current.link.startsWith('http') ? 'noopener noreferrer' : undefined}
+              >
+                Learn More
+                <svg className="w-4 h-4 ml-1.5" fill="none" stroke="currentColor" viewBox="0 0 24 24">
+                  <path strokeLinecap="round" strokeLinejoin="round" strokeWidth={2} d="M9 5l7 7-7 7" />
+                </svg>
+              </a>
+            </div>
+          )}
+
+          {/* Footer actions */}
+          <div className="flex items-center justify-between pt-4 border-t border-gray-200 dark:border-gray-700">
+            <div className="flex items-center space-x-2">
+              {total > 1 && (
+                <Button
+                  variant="ghost"
+                  size="sm"
+                  onClick={handlePrev}
+                  disabled={currentIndex === 0 || isDismissing}
+                >
+                  Previous
+                </Button>
+              )}
+              {currentIndex < total - 1 && (
+                <Button
+                  variant="ghost"
+                  size="sm"
+                  onClick={handleNext}
+                  disabled={isDismissing}
+                >
+                  Next
+                </Button>
+              )}
+            </div>
+            <div className="flex items-center space-x-2">
+              {total > 1 && (
+                <Button
+                  variant="ghost"
+                  size="sm"
+                  onClick={handleDismissAll}
+                  disabled={isDismissing}
+                >
+                  Dismiss All
+                </Button>
+              )}
+              <Button
+                variant="primary"
+                size="sm"
+                onClick={handleDismissCurrent}
+                disabled={isDismissing}
+              >
+                {isDismissing ? 'Dismissing...' : 'Got It'}
+              </Button>
+            </div>
+          </div>
+        </Card>
+      </div>
+    </div>
+  );
+}

--- a/frontend/components/BroadcastModal.tsx
+++ b/frontend/components/BroadcastModal.tsx
@@ -3,7 +3,6 @@
 import { useState, useEffect, useRef, useCallback } from 'react';
 import { apiClient } from '@/lib/api';
 import { Card } from '@/components/ui/Card';
-import { Button } from '@/components/ui/Button';
 import MarkdownRenderer from '@/components/MarkdownRenderer';
 import type { BroadcastItem } from '@/lib/types';
 import { format } from 'date-fns';
@@ -40,8 +39,6 @@ export function BroadcastModal({ broadcasts: initialBroadcasts, onAllDismissed }
   // Focus management
   useEffect(() => {
     previousFocusRef.current = document.activeElement as HTMLElement;
-    const firstButton = modalRef.current?.querySelector<HTMLElement>('button');
-    firstButton?.focus();
     return () => {
       previousFocusRef.current?.focus();
     };
@@ -135,119 +132,133 @@ export function BroadcastModal({ broadcasts: initialBroadcasts, onAllDismissed }
       className={`fixed inset-0 z-50 flex items-center justify-center p-4 transition-opacity duration-300 ${
         isVisible ? 'opacity-100' : 'opacity-0'
       }`}
+      onClick={handleDismissCurrent}
       role="dialog"
       aria-modal="true"
       aria-labelledby="broadcast-modal-title"
     >
       {/* Backdrop */}
-      <div className="absolute inset-0 bg-black/60 backdrop-blur-sm" />
+      <div className="absolute inset-0 bg-black/50 backdrop-blur-sm" />
 
       {/* Modal */}
       <div
         ref={modalRef}
-        className={`relative w-full max-w-lg max-h-[80vh] flex flex-col transform transition-all duration-300 ${
+        className={`relative w-full max-w-2xl max-h-[90vh] overflow-y-auto transform transition-all duration-300 ${
           isVisible ? 'scale-100 translate-y-0' : 'scale-95 translate-y-4'
         }`}
+        onClick={(e) => e.stopPropagation()}
       >
-        <Card padding="lg">
+        <Card padding="lg" className="m-2 sm:m-0">
           {/* Header */}
-          <div className="flex items-center justify-between mb-4">
-            <div className="flex items-center space-x-2">
-              <span className="text-xl" aria-hidden="true">📢</span>
-              <span className="text-sm text-gray-500 dark:text-gray-400 font-medium">
-                {currentIndex + 1} of {total}
-              </span>
-            </div>
-            <button
-              onClick={handleDismissCurrent}
-              className="text-gray-400 hover:text-gray-600 dark:hover:text-gray-300 transition-colors"
-              aria-label="Dismiss this announcement"
-              disabled={isDismissing}
-            >
-              <svg className="w-5 h-5" fill="none" stroke="currentColor" viewBox="0 0 24 24">
-                <path strokeLinecap="round" strokeLinejoin="round" strokeWidth={2} d="M6 18L18 6M6 6l12 12" />
+          <div className="text-center mb-4 sm:mb-6">
+            <div className="mb-3 sm:mb-4">
+              <svg
+                className="w-16 h-16 sm:w-20 sm:h-20 mx-auto text-amber-500 dark:text-amber-400"
+                fill="none"
+                stroke="currentColor"
+                viewBox="0 0 24 24"
+                aria-hidden="true"
+              >
+                <path
+                  strokeLinecap="round"
+                  strokeLinejoin="round"
+                  strokeWidth={2}
+                  d="M11 5.882V19.24a1.76 1.76 0 01-3.417.592l-2.147-6.15M18 13a3 3 0 100-6M5.436 13.683A4.001 4.001 0 017 6h1.832c4.1 0 7.625-1.234 9.168-3v14c-1.543-1.766-5.067-3-9.168-3H7a3.988 3.988 0 01-1.564-.317z"
+                />
               </svg>
-            </button>
+            </div>
+            <h2
+              id="broadcast-modal-title"
+              className="text-2xl sm:text-3xl font-bold text-gray-900 dark:text-gray-100 mb-2"
+            >
+              {current.title}
+            </h2>
+            <p className="text-sm text-gray-500 dark:text-gray-400">
+              {formatDate(current.created_at)}
+              {total > 1 && (
+                <span className="ml-2 inline-flex items-center px-2 py-0.5 rounded-full text-xs font-medium bg-gray-100 dark:bg-gray-800 text-gray-600 dark:text-gray-400">
+                  {currentIndex + 1} of {total}
+                </span>
+              )}
+            </p>
           </div>
 
-          {/* Title */}
-          <h2
-            id="broadcast-modal-title"
-            className="text-xl font-bold text-gray-900 dark:text-gray-100 mb-1"
-          >
-            {current.title}
-          </h2>
-          <p className="text-xs text-gray-500 dark:text-gray-400 mb-4">
-            {formatDate(current.created_at)}
-          </p>
-
-          {/* Body — scrollable */}
-          <div className="overflow-y-auto max-h-[40vh] mb-4 pr-1">
-            <div className="prose prose-sm dark:prose-invert max-w-none">
-              <MarkdownRenderer markdown={current.message} />
+          {/* Body */}
+          <div className="mb-6 sm:mb-8">
+            <div className="bg-gray-50 dark:bg-gray-800/50 rounded-lg p-4 sm:p-6">
+              <div className="prose prose-sm dark:prose-invert max-w-none prose-headings:text-gray-900 dark:prose-headings:text-gray-100 prose-p:text-gray-700 dark:prose-p:text-gray-300">
+                <MarkdownRenderer markdown={current.message} />
+              </div>
             </div>
           </div>
 
-          {/* CTA Link */}
-          {current.link && (
-            <div className="mb-4">
+          {/* Actions */}
+          <div className="flex flex-col gap-2 sm:gap-3">
+            {/* CTA Link (if provided) */}
+            {current.link && (
               <a
                 href={current.link}
-                className="inline-flex items-center px-4 py-2 bg-amber-500 hover:bg-amber-600 text-gray-900 font-semibold text-sm rounded-lg transition-colors"
+                className="inline-flex items-center justify-center px-4 sm:px-6 py-2.5 sm:py-3 text-sm sm:text-base bg-amber-500 dark:bg-amber-400 text-gray-900 font-semibold rounded-lg hover:bg-amber-600 dark:hover:bg-amber-500 transition-colors focus:outline-none focus:ring-2 focus:ring-amber-500 focus:ring-offset-2 dark:focus:ring-offset-gray-950"
                 target={current.link.startsWith('http') ? '_blank' : undefined}
                 rel={current.link.startsWith('http') ? 'noopener noreferrer' : undefined}
+                onClick={handleDismissCurrent}
               >
-                Learn More
-                <svg className="w-4 h-4 ml-1.5" fill="none" stroke="currentColor" viewBox="0 0 24 24">
-                  <path strokeLinecap="round" strokeLinejoin="round" strokeWidth={2} d="M9 5l7 7-7 7" />
+                <span>Check It Out</span>
+                <svg className="w-4 h-4 sm:w-5 sm:h-5 ml-2" fill="none" stroke="currentColor" viewBox="0 0 24 24">
+                  <path strokeLinecap="round" strokeLinejoin="round" strokeWidth={2} d="M14 5l7 7m0 0l-7 7m7-7H3" />
                 </svg>
               </a>
-            </div>
-          )}
+            )}
 
-          {/* Footer actions */}
-          <div className="flex items-center justify-between pt-4 border-t border-gray-200 dark:border-gray-700">
-            <div className="flex items-center space-x-2">
-              {total > 1 && (
-                <Button
-                  variant="ghost"
-                  size="sm"
-                  onClick={handlePrev}
-                  disabled={currentIndex === 0 || isDismissing}
-                >
-                  Previous
-                </Button>
-              )}
-              {currentIndex < total - 1 && (
-                <Button
-                  variant="ghost"
-                  size="sm"
-                  onClick={handleNext}
+            {/* Dismiss / Navigation row */}
+            <div className="flex items-center justify-between">
+              {/* Left: navigation */}
+              <div className="flex items-center gap-2">
+                {total > 1 && currentIndex > 0 && (
+                  <button
+                    onClick={handlePrev}
+                    disabled={isDismissing}
+                    className="inline-flex items-center px-3 py-2 text-sm text-gray-600 dark:text-gray-400 hover:text-gray-900 dark:hover:text-gray-100 transition-colors disabled:opacity-50"
+                  >
+                    <svg className="w-4 h-4 mr-1" fill="none" stroke="currentColor" viewBox="0 0 24 24">
+                      <path strokeLinecap="round" strokeLinejoin="round" strokeWidth={2} d="M15 19l-7-7 7-7" />
+                    </svg>
+                    Previous
+                  </button>
+                )}
+                {total > 1 && currentIndex < total - 1 && (
+                  <button
+                    onClick={handleNext}
+                    disabled={isDismissing}
+                    className="inline-flex items-center px-3 py-2 text-sm text-gray-600 dark:text-gray-400 hover:text-gray-900 dark:hover:text-gray-100 transition-colors disabled:opacity-50"
+                  >
+                    Next
+                    <svg className="w-4 h-4 ml-1" fill="none" stroke="currentColor" viewBox="0 0 24 24">
+                      <path strokeLinecap="round" strokeLinejoin="round" strokeWidth={2} d="M9 5l7 7-7 7" />
+                    </svg>
+                  </button>
+                )}
+              </div>
+
+              {/* Right: dismiss actions */}
+              <div className="flex items-center gap-2">
+                {total > 1 && (
+                  <button
+                    onClick={handleDismissAll}
+                    disabled={isDismissing}
+                    className="px-3 py-2 text-sm text-gray-500 dark:text-gray-400 hover:text-gray-700 dark:hover:text-gray-300 transition-colors disabled:opacity-50"
+                  >
+                    Dismiss All
+                  </button>
+                )}
+                <button
+                  onClick={handleDismissCurrent}
                   disabled={isDismissing}
+                  className="inline-flex items-center justify-center px-4 sm:px-6 py-2.5 sm:py-3 text-sm sm:text-base bg-gray-100 dark:bg-gray-800 text-gray-900 dark:text-gray-100 font-semibold rounded-lg hover:bg-gray-200 dark:hover:bg-gray-700 transition-colors focus:outline-none focus:ring-2 focus:ring-gray-500 focus:ring-offset-2 dark:focus:ring-offset-gray-950"
                 >
-                  Next
-                </Button>
-              )}
-            </div>
-            <div className="flex items-center space-x-2">
-              {total > 1 && (
-                <Button
-                  variant="ghost"
-                  size="sm"
-                  onClick={handleDismissAll}
-                  disabled={isDismissing}
-                >
-                  Dismiss All
-                </Button>
-              )}
-              <Button
-                variant="primary"
-                size="sm"
-                onClick={handleDismissCurrent}
-                disabled={isDismissing}
-              >
-                {isDismissing ? 'Dismissing...' : 'Got It'}
-              </Button>
+                  {isDismissing ? 'Dismissing...' : 'Got It'}
+                </button>
+              </div>
             </div>
           </div>
         </Card>

--- a/frontend/components/WalkthroughBrowser.tsx
+++ b/frontend/components/WalkthroughBrowser.tsx
@@ -7,11 +7,13 @@ import { Button } from '@/components/ui/Button';
 
 interface WalkthroughBrowserProps {
   initialWalkthroughs: WalkthroughWithProgress[];
+  lockedWalkthroughs?: Record<string, string>;
+  membershipTier?: string;
 }
 
 const ITEMS_PER_PAGE = 12; // Display 12 walkthroughs per page (4x3 grid)
 
-export function WalkthroughBrowser({ initialWalkthroughs }: WalkthroughBrowserProps) {
+export function WalkthroughBrowser({ initialWalkthroughs, lockedWalkthroughs = {}, membershipTier = 'FREE' }: WalkthroughBrowserProps) {
   const router = useRouter();
   const searchParams = useSearchParams();
   const mainHeadingRef = useRef<HTMLHeadingElement>(null);
@@ -247,13 +249,33 @@ export function WalkthroughBrowser({ initialWalkthroughs }: WalkthroughBrowserPr
       ) : (
         <>
           <div className="grid grid-cols-1 md:grid-cols-2 lg:grid-cols-3 gap-6">
-            {paginatedWalkthroughs.map(walkthrough => (
+            {paginatedWalkthroughs.map(walkthrough => {
+            const isLocked = lockedWalkthroughs[walkthrough.id] === 'BUILDER';
+            const userHasAccess = membershipTier === 'BUILDER' || !isLocked;
+
+            return (
             <a
               key={walkthrough.id}
               href={`/walkthroughs/${walkthrough.id}`}
               className="block group"
             >
-              <div className="bg-white dark:bg-gray-900 border border-gray-200 dark:border-gray-800 rounded-lg p-6 hover:border-primary-400 dark:hover:border-primary-400 transition-all hover:shadow-lg h-full flex flex-col">
+              <div className={`bg-white dark:bg-gray-900 border rounded-lg p-6 hover:shadow-lg h-full flex flex-col transition-all ${
+                isLocked && !userHasAccess
+                  ? 'border-amber-300 dark:border-amber-700 hover:border-amber-400 dark:hover:border-amber-500'
+                  : 'border-gray-200 dark:border-gray-800 hover:border-primary-400 dark:hover:border-primary-400'
+              }`}>
+                {/* Builder badge */}
+                {isLocked && (
+                  <div className="flex items-center gap-1.5 mb-3">
+                    <svg className="w-3.5 h-3.5 text-amber-600 dark:text-amber-400" fill="currentColor" viewBox="0 0 20 20" aria-hidden="true">
+                      <path fillRule="evenodd" d="M5 9V7a5 5 0 0110 0v2a2 2 0 012 2v5a2 2 0 01-2 2H5a2 2 0 01-2-2v-5a2 2 0 012-2zm8-2v2H7V7a3 3 0 016 0z" clipRule="evenodd" />
+                    </svg>
+                    <span className="text-xs font-semibold text-amber-700 dark:text-amber-400 uppercase tracking-wide">
+                      Builder
+                    </span>
+                  </div>
+                )}
+
                 {/* Header with Title and Status */}
                 <div className="flex items-start justify-between mb-3">
                   <h2 className="text-lg font-semibold text-gray-900 dark:text-gray-100 group-hover:text-primary-500 dark:group-hover:text-primary-400 transition-colors flex-1">
@@ -305,16 +327,26 @@ export function WalkthroughBrowser({ initialWalkthroughs }: WalkthroughBrowserPr
 
                 {/* Action Indicator */}
                 <div className="mt-4 pt-4 border-t border-gray-200 dark:border-gray-800">
-                  <div className="flex items-center text-primary-500 dark:text-primary-400 font-medium text-sm group-hover:text-primary-600 dark:group-hover:text-primary-300 transition-colors">
-                    <span>View Walkthrough</span>
-                    <svg className="w-4 h-4 ml-2 group-hover:translate-x-1 transition-transform" fill="none" stroke="currentColor" viewBox="0 0 24 24">
-                      <path strokeLinecap="round" strokeLinejoin="round" strokeWidth={2} d="M9 5l7 7-7 7" />
-                    </svg>
-                  </div>
+                  {isLocked && !userHasAccess ? (
+                    <div className="flex items-center text-amber-600 dark:text-amber-400 font-medium text-sm">
+                      <svg className="w-4 h-4 mr-2" fill="currentColor" viewBox="0 0 20 20" aria-hidden="true">
+                        <path fillRule="evenodd" d="M5 9V7a5 5 0 0110 0v2a2 2 0 012 2v5a2 2 0 01-2 2H5a2 2 0 01-2-2v-5a2 2 0 012-2zm8-2v2H7V7a3 3 0 016 0z" clipRule="evenodd" />
+                      </svg>
+                      <span>Upgrade to Access</span>
+                    </div>
+                  ) : (
+                    <div className="flex items-center text-primary-500 dark:text-primary-400 font-medium text-sm group-hover:text-primary-600 dark:group-hover:text-primary-300 transition-colors">
+                      <span>View Walkthrough</span>
+                      <svg className="w-4 h-4 ml-2 group-hover:translate-x-1 transition-transform" fill="none" stroke="currentColor" viewBox="0 0 24 24">
+                        <path strokeLinecap="round" strokeLinejoin="round" strokeWidth={2} d="M9 5l7 7-7 7" />
+                      </svg>
+                    </div>
+                  )}
                 </div>
               </div>
             </a>
-          ))}
+          );
+          })}
         </div>
 
         {/* Pagination Controls */}

--- a/frontend/components/WalkthroughPageTemplate.tsx
+++ b/frontend/components/WalkthroughPageTemplate.tsx
@@ -26,18 +26,25 @@ export function WalkthroughPageTemplate({ walkthrough: initialWalkthrough, readm
   const [error, setError] = useState<string | null>(null);
   const [membershipTier, setMembershipTier] = useState<string>('FREE');
   const [tierLoading, setTierLoading] = useState(true);
+  const [walkthroughLocked, setWalkthroughLocked] = useState(false);
 
   useEffect(() => {
     async function checkSubscription() {
       if (!isAuthenticated) return;
-      const { data } = await apiClient.get<{ membership_tier: string }>('/api/stripe/subscription');
-      if (data?.membership_tier) {
-        setMembershipTier(data.membership_tier);
+      const [subRes, tiersRes] = await Promise.all([
+        apiClient.get<{ membership_tier: string }>('/api/stripe/subscription'),
+        apiClient.getWalkthroughAccessTiers(),
+      ]);
+      if (subRes.data?.membership_tier) {
+        setMembershipTier(subRes.data.membership_tier);
+      }
+      if (tiersRes.data?.access_tiers) {
+        setWalkthroughLocked(tiersRes.data.access_tiers[initialWalkthrough.id] === 'BUILDER');
       }
       setTierLoading(false);
     }
     checkSubscription();
-  }, [isAuthenticated]);
+  }, [isAuthenticated, initialWalkthrough.id]);
 
   useEffect(() => {
     const loadProgress = async () => {
@@ -61,7 +68,8 @@ export function WalkthroughPageTemplate({ walkthrough: initialWalkthrough, readm
           progress
         });
 
-        if (progress.status === 'not_started') {
+        // Only auto-start progress if user has access
+        if (progress.status === 'not_started' && !walkthroughLocked || (walkthroughLocked && membershipTier === 'BUILDER')) {
           try {
             const result = await apiClient.updateWalkthroughProgress(initialWalkthrough.id, 'in_progress');
             if (result.data) {
@@ -90,8 +98,11 @@ export function WalkthroughPageTemplate({ walkthrough: initialWalkthrough, readm
       }
     };
 
-    loadProgress();
-  }, [initialWalkthrough, readme]);
+    // Wait for tier loading to complete before loading progress
+    if (!tierLoading) {
+      loadProgress();
+    }
+  }, [initialWalkthrough, readme, tierLoading, walkthroughLocked, membershipTier]);
 
   const handleMarkComplete = async () => {
     if (!walkthrough) return;
@@ -117,7 +128,7 @@ export function WalkthroughPageTemplate({ walkthrough: initialWalkthrough, readm
     }
   };
 
-  const hasAccess = true; // Pricing disabled for launch — all users have access
+  const hasAccess = !walkthroughLocked || membershipTier === 'BUILDER';
 
   return (
     <AuthGuard>

--- a/frontend/components/WalkthroughPageTemplate.tsx
+++ b/frontend/components/WalkthroughPageTemplate.tsx
@@ -252,13 +252,13 @@ export function WalkthroughPageTemplate({ walkthrough: initialWalkthrough, readm
                             Upgrade to continue
                           </h3>
                           <p className="text-sm text-gray-500 dark:text-gray-400 mb-6 leading-relaxed">
-                            The full walkthrough — including step-by-step instructions, code, deployment guides, and troubleshooting playbooks — is available to Explorer members and above.
+                            The full walkthrough — including step-by-step instructions, code, deployment guides, and troubleshooting playbooks — is available to Builder members.
                           </p>
                           <a
                             href="/pricing"
                             className="inline-block px-8 py-3.5 bg-primary-400 hover:bg-primary-500 text-gray-900 font-semibold rounded-xl transition-colors"
                           >
-                            Upgrade to Explorer
+                            Upgrade to Builder
                           </a>
                         </div>
                       </div>

--- a/frontend/components/admin/BroadcastManagement.tsx
+++ b/frontend/components/admin/BroadcastManagement.tsx
@@ -1,0 +1,301 @@
+'use client';
+
+import { useEffect, useState } from 'react';
+import { apiClient } from '@/lib/api';
+import { Button } from '@/components/ui/Button';
+import { Spinner } from '@/components/ui/Spinner';
+import MarkdownRenderer from '@/components/MarkdownRenderer';
+import type { BroadcastItem } from '@/lib/types';
+import { format } from 'date-fns';
+
+export function BroadcastManagement() {
+  // Compose form state
+  const [title, setTitle] = useState('');
+  const [message, setMessage] = useState('');
+  const [link, setLink] = useState('');
+  const [isSending, setIsSending] = useState(false);
+  const [showPreview, setShowPreview] = useState(false);
+  const [showConfirm, setShowConfirm] = useState(false);
+  const [composeError, setComposeError] = useState<string | null>(null);
+  const [composeSuccess, setComposeSuccess] = useState<string | null>(null);
+
+  // History state
+  const [broadcasts, setBroadcasts] = useState<BroadcastItem[]>([]);
+  const [isLoading, setIsLoading] = useState(true);
+  const [historyError, setHistoryError] = useState<string | null>(null);
+  const [deletingId, setDeletingId] = useState<string | null>(null);
+
+  useEffect(() => {
+    fetchBroadcasts();
+  }, []);
+
+  const fetchBroadcasts = async () => {
+    setIsLoading(true);
+    setHistoryError(null);
+    try {
+      const { data, error } = await apiClient.getAdminBroadcasts();
+      if (error) {
+        setHistoryError(error);
+        return;
+      }
+      if (data?.broadcasts) {
+        setBroadcasts(data.broadcasts);
+      }
+    } catch (err) {
+      setHistoryError(err instanceof Error ? err.message : 'Failed to load broadcasts');
+    } finally {
+      setIsLoading(false);
+    }
+  };
+
+  const handleSend = async () => {
+    setComposeError(null);
+    setComposeSuccess(null);
+
+    if (!title.trim()) {
+      setComposeError('Title is required');
+      return;
+    }
+    if (title.trim().length > 100) {
+      setComposeError('Title must be 100 characters or less');
+      return;
+    }
+    if (!message.trim()) {
+      setComposeError('Message is required');
+      return;
+    }
+    if (message.trim().length > 2000) {
+      setComposeError('Message must be 2000 characters or less');
+      return;
+    }
+
+    setShowConfirm(true);
+  };
+
+  const confirmSend = async () => {
+    setShowConfirm(false);
+    setIsSending(true);
+    setComposeError(null);
+
+    try {
+      const { data, error } = await apiClient.createBroadcast(
+        title.trim(),
+        message.trim(),
+        link.trim() || undefined
+      );
+      if (error) {
+        setComposeError(error);
+        return;
+      }
+      setComposeSuccess('Broadcast sent to all users');
+      setTitle('');
+      setMessage('');
+      setLink('');
+      setShowPreview(false);
+      setTimeout(() => setComposeSuccess(null), 5000);
+      // Refresh history
+      fetchBroadcasts();
+    } catch (err) {
+      setComposeError(err instanceof Error ? err.message : 'Failed to send broadcast');
+    } finally {
+      setIsSending(false);
+    }
+  };
+
+  const handleDelete = async (broadcastId: string) => {
+    if (!confirm('Delete this broadcast? This cannot be undone.')) return;
+    setDeletingId(broadcastId);
+    try {
+      const { error } = await apiClient.deleteBroadcast(broadcastId);
+      if (error) {
+        setHistoryError(error);
+        return;
+      }
+      setBroadcasts((prev) => prev.filter((b) => b.broadcast_id !== broadcastId));
+    } catch (err) {
+      setHistoryError(err instanceof Error ? err.message : 'Failed to delete');
+    } finally {
+      setDeletingId(null);
+    }
+  };
+
+  const formatDate = (dateStr: string) => {
+    try {
+      return format(new Date(dateStr), 'MMM d, yyyy h:mm a');
+    } catch {
+      return dateStr;
+    }
+  };
+
+  return (
+    <div>
+      <h2 className="text-xl font-semibold text-gray-900 dark:text-gray-100 mb-6">
+        Broadcast Notifications
+      </h2>
+
+      {/* Compose Form */}
+      <div className="mb-8 rounded-lg border border-gray-200 dark:border-gray-700 p-5 space-y-4">
+        <h3 className="text-sm font-semibold text-gray-700 dark:text-gray-300">
+          Send New Broadcast
+        </h3>
+
+        {/* Title */}
+        <div>
+          <label htmlFor="broadcast-title" className="block text-sm font-medium text-gray-700 dark:text-gray-300 mb-1">
+            Title <span className="text-gray-400">({title.length}/100)</span>
+          </label>
+          <input
+            id="broadcast-title"
+            type="text"
+            value={title}
+            onChange={(e) => setTitle(e.target.value)}
+            maxLength={100}
+            placeholder="e.g. New Walkthrough Available!"
+            className="w-full rounded-md border border-gray-300 dark:border-gray-600 bg-white dark:bg-gray-800 text-sm text-gray-900 dark:text-gray-100 px-3 py-2 focus:outline-none focus:ring-2 focus:ring-amber-500"
+          />
+        </div>
+
+        {/* Message with preview toggle */}
+        <div>
+          <div className="flex items-center justify-between mb-1">
+            <label htmlFor="broadcast-message" className="block text-sm font-medium text-gray-700 dark:text-gray-300">
+              Message (Markdown) <span className="text-gray-400">({message.length}/2000)</span>
+            </label>
+            <button
+              type="button"
+              onClick={() => setShowPreview(!showPreview)}
+              className="text-xs font-medium text-amber-600 dark:text-amber-400 hover:text-amber-700 dark:hover:text-amber-300"
+            >
+              {showPreview ? 'Edit' : 'Preview'}
+            </button>
+          </div>
+          {showPreview ? (
+            <div className="min-h-[120px] rounded-md border border-gray-300 dark:border-gray-600 bg-gray-50 dark:bg-gray-800 p-3 overflow-y-auto max-h-[200px]">
+              {message.trim() ? (
+                <div className="prose prose-sm dark:prose-invert max-w-none">
+                  <MarkdownRenderer markdown={message} />
+                </div>
+              ) : (
+                <p className="text-sm text-gray-400 italic">Nothing to preview</p>
+              )}
+            </div>
+          ) : (
+            <textarea
+              id="broadcast-message"
+              value={message}
+              onChange={(e) => setMessage(e.target.value)}
+              maxLength={2000}
+              rows={5}
+              placeholder="Write your announcement in markdown..."
+              className="w-full rounded-md border border-gray-300 dark:border-gray-600 bg-white dark:bg-gray-800 text-sm text-gray-900 dark:text-gray-100 px-3 py-2 focus:outline-none focus:ring-2 focus:ring-amber-500 resize-y"
+            />
+          )}
+        </div>
+
+        {/* Link */}
+        <div>
+          <label htmlFor="broadcast-link" className="block text-sm font-medium text-gray-700 dark:text-gray-300 mb-1">
+            Link (optional)
+          </label>
+          <input
+            id="broadcast-link"
+            type="text"
+            value={link}
+            onChange={(e) => setLink(e.target.value)}
+            placeholder="/walkthroughs/new-walkthrough or https://..."
+            className="w-full rounded-md border border-gray-300 dark:border-gray-600 bg-white dark:bg-gray-800 text-sm text-gray-900 dark:text-gray-100 px-3 py-2 focus:outline-none focus:ring-2 focus:ring-amber-500"
+          />
+        </div>
+
+        {/* Actions */}
+        <div className="flex items-center space-x-3">
+          <Button
+            variant="primary"
+            size="sm"
+            onClick={handleSend}
+            disabled={isSending || !title.trim() || !message.trim()}
+          >
+            {isSending ? 'Sending...' : 'Send Broadcast'}
+          </Button>
+        </div>
+
+        {/* Confirmation dialog */}
+        {showConfirm && (
+          <div className="bg-amber-50 dark:bg-amber-900/20 border border-amber-200 dark:border-amber-800 rounded-lg p-4">
+            <p className="text-sm text-amber-800 dark:text-amber-200 mb-3">
+              This will send an email to all registered users and show as a modal on their next login. Continue?
+            </p>
+            <div className="flex items-center space-x-2">
+              <Button variant="primary" size="sm" onClick={confirmSend} disabled={isSending}>
+                {isSending ? 'Sending...' : 'Confirm Send'}
+              </Button>
+              <Button variant="ghost" size="sm" onClick={() => setShowConfirm(false)}>
+                Cancel
+              </Button>
+            </div>
+          </div>
+        )}
+
+        {composeSuccess && (
+          <p className="text-sm text-green-600 dark:text-green-400">{composeSuccess}</p>
+        )}
+        {composeError && (
+          <p className="text-sm text-red-600 dark:text-red-400">{composeError}</p>
+        )}
+      </div>
+
+      {/* Broadcast History */}
+      <div>
+        <h3 className="text-sm font-semibold text-gray-700 dark:text-gray-300 mb-3">
+          Broadcast History
+        </h3>
+
+        {isLoading ? (
+          <div className="flex items-center justify-center py-8">
+            <Spinner size="md" />
+          </div>
+        ) : historyError ? (
+          <div className="bg-red-50 dark:bg-red-900/20 border border-red-200 dark:border-red-800 rounded-lg p-4">
+            <p className="text-sm text-red-800 dark:text-red-200">{historyError}</p>
+            <button
+              onClick={fetchBroadcasts}
+              className="mt-2 text-sm font-medium text-red-600 dark:text-red-400 hover:text-red-700"
+            >
+              Try Again
+            </button>
+          </div>
+        ) : broadcasts.length === 0 ? (
+          <p className="text-sm text-gray-500 dark:text-gray-400 py-4">
+            No broadcasts sent yet.
+          </p>
+        ) : (
+          <div className="space-y-2">
+            {broadcasts.map((broadcast) => (
+              <div
+                key={broadcast.broadcast_id}
+                className="flex items-center justify-between rounded-lg border border-gray-200 dark:border-gray-700 px-4 py-3"
+              >
+                <div className="flex-1 min-w-0 mr-4">
+                  <div className="text-sm font-medium text-gray-900 dark:text-gray-100 truncate">
+                    {broadcast.title}
+                  </div>
+                  <div className="text-xs text-gray-500 dark:text-gray-400">
+                    {formatDate(broadcast.created_at)} by {broadcast.created_by}
+                  </div>
+                </div>
+                <Button
+                  variant="danger"
+                  size="sm"
+                  onClick={() => handleDelete(broadcast.broadcast_id)}
+                  disabled={deletingId === broadcast.broadcast_id}
+                >
+                  {deletingId === broadcast.broadcast_id ? 'Deleting...' : 'Delete'}
+                </Button>
+              </div>
+            ))}
+          </div>
+        )}
+      </div>
+    </div>
+  );
+}

--- a/frontend/components/admin/UserList.tsx
+++ b/frontend/components/admin/UserList.tsx
@@ -228,6 +228,9 @@ export function UserList() {
                   Provider
                 </th>
                 <th className="text-left py-3 px-4 text-sm font-semibold text-gray-900 dark:text-gray-100">
+                  Role
+                </th>
+                <th className="text-left py-3 px-4 text-sm font-semibold text-gray-900 dark:text-gray-100">
                   Registered
                 </th>
                 <th className="text-left py-3 px-4 text-sm font-semibold text-gray-900 dark:text-gray-100">
@@ -288,6 +291,15 @@ export function UserList() {
                     >
                       {providerLabel(user.provider)}
                     </span>
+                  </td>
+                  <td className="py-3 px-4">
+                    {user.contributor_role ? (
+                      <span className="inline-flex items-center px-2 py-0.5 rounded-full text-xs font-medium bg-purple-100 text-purple-800 dark:bg-purple-900/30 dark:text-purple-400">
+                        Contributor
+                      </span>
+                    ) : (
+                      <span className="text-xs text-gray-400 dark:text-gray-600">—</span>
+                    )}
                   </td>
                   <td className="py-3 px-4">
                     <span className="text-sm text-gray-600 dark:text-gray-400">
@@ -357,6 +369,14 @@ export function UserList() {
                     >
                       {providerLabel(user.provider)}
                     </span>
+                    {user.contributor_role && (
+                      <>
+                        {' · '}
+                        <span className="inline-flex items-center px-1.5 py-0.5 rounded-full text-xs font-medium bg-purple-100 text-purple-800 dark:bg-purple-900/30 dark:text-purple-400">
+                          Contributor
+                        </span>
+                      </>
+                    )}
                   </div>
                 </div>
               </div>

--- a/frontend/components/admin/UserProfileModal.tsx
+++ b/frontend/components/admin/UserProfileModal.tsx
@@ -22,6 +22,12 @@ export function UserProfileModal({ userId, onClose }: UserProfileModalProps) {
   const modalRef = useRef<HTMLDivElement>(null);
   const previousFocusRef = useRef<HTMLElement | null>(null);
 
+  // Contributor role state
+  const [isSavingRole, setIsSavingRole] = useState(false);
+  const [isRemovingRole, setIsRemovingRole] = useState(false);
+  const [roleSuccess, setRoleSuccess] = useState<string | null>(null);
+  const [roleError, setRoleError] = useState<string | null>(null);
+
   // Animate in
   useEffect(() => {
     setTimeout(() => setIsVisible(true), 10);
@@ -99,6 +105,50 @@ export function UserProfileModal({ userId, onClose }: UserProfileModalProps) {
       setError(err instanceof Error ? err.message : 'Failed to fetch user profile');
     } finally {
       setIsLoading(false);
+    }
+  };
+
+  const handleSaveRole = async () => {
+    setIsSavingRole(true);
+    setRoleError(null);
+    setRoleSuccess(null);
+    try {
+      const { data, error: apiError } = await apiClient.setContributorRole(userId, 'contributor');
+      if (apiError) {
+        setRoleError(apiError);
+        return;
+      }
+      if (data) {
+        setProfile((prev) =>
+          prev ? { ...prev, contributor_role: data.contributor_role } : prev
+        );
+        setRoleSuccess('Contributor role assigned');
+        setTimeout(() => setRoleSuccess(null), 3000);
+      }
+    } catch (err) {
+      setRoleError(err instanceof Error ? err.message : 'Failed to assign role');
+    } finally {
+      setIsSavingRole(false);
+    }
+  };
+
+  const handleRemoveRole = async () => {
+    setIsRemovingRole(true);
+    setRoleError(null);
+    setRoleSuccess(null);
+    try {
+      const { error: apiError } = await apiClient.deleteContributorRole(userId);
+      if (apiError) {
+        setRoleError(apiError);
+        return;
+      }
+      setProfile((prev) => (prev ? { ...prev, contributor_role: null } : prev));
+      setRoleSuccess('Contributor role removed');
+      setTimeout(() => setRoleSuccess(null), 3000);
+    } catch (err) {
+      setRoleError(err instanceof Error ? err.message : 'Failed to remove role');
+    } finally {
+      setIsRemovingRole(false);
     }
   };
 
@@ -315,6 +365,55 @@ export function UserProfileModal({ userId, onClose }: UserProfileModalProps) {
                     </div>
                   </div>
                 )}
+
+                {/* Contributor Role */}
+                <div>
+                  <h4 className="text-sm font-semibold text-gray-700 dark:text-gray-300 mb-3">
+                    Contributor Role
+                  </h4>
+                  <div className="rounded-lg border border-gray-200 dark:border-gray-700 p-4 space-y-3">
+                    {profile.contributor_role ? (
+                      <div className="flex items-center justify-between">
+                        <div className="flex items-center space-x-2">
+                          <span className="inline-flex items-center px-2.5 py-0.5 rounded-full text-xs font-medium bg-purple-100 text-purple-800 dark:bg-purple-900/30 dark:text-purple-400">
+                            Contributor
+                          </span>
+                          <span className="text-xs text-gray-400 dark:text-gray-500">
+                            assigned by {profile.contributor_role.assigned_by} on {formatDate(profile.contributor_role.assigned_at)}
+                          </span>
+                        </div>
+                        <Button
+                          variant="danger"
+                          size="sm"
+                          onClick={handleRemoveRole}
+                          disabled={isRemovingRole}
+                        >
+                          {isRemovingRole ? 'Removing...' : 'Remove'}
+                        </Button>
+                      </div>
+                    ) : (
+                      <div className="flex items-center justify-between">
+                        <span className="text-sm text-gray-500 dark:text-gray-400">
+                          No contributor role assigned
+                        </span>
+                        <Button
+                          variant="primary"
+                          size="sm"
+                          onClick={handleSaveRole}
+                          disabled={isSavingRole}
+                        >
+                          {isSavingRole ? 'Assigning...' : 'Assign Contributor'}
+                        </Button>
+                      </div>
+                    )}
+                    {roleSuccess && (
+                      <p className="text-xs text-green-600 dark:text-green-400">{roleSuccess}</p>
+                    )}
+                    {roleError && (
+                      <p className="text-xs text-red-600 dark:text-red-400">{roleError}</p>
+                    )}
+                  </div>
+                </div>
 
                 {/* Discord & Membership */}
                 <div>

--- a/frontend/components/admin/WalkthroughAccessTiers.tsx
+++ b/frontend/components/admin/WalkthroughAccessTiers.tsx
@@ -1,0 +1,204 @@
+'use client';
+
+import { useEffect, useState } from 'react';
+import { apiClient } from '@/lib/api';
+import { WALKTHROUGHS_DATA } from '@/lib/walkthroughs-data';
+import { Spinner } from '@/components/ui/Spinner';
+
+interface WalkthroughTierItem {
+  id: string;
+  title: string;
+  difficulty: string;
+  accessTier: 'FREE' | 'BUILDER';
+}
+
+export function WalkthroughAccessTiers() {
+  const [walkthroughs, setWalkthroughs] = useState<WalkthroughTierItem[]>([]);
+  const [isLoading, setIsLoading] = useState(true);
+  const [error, setError] = useState<string | null>(null);
+  const [updatingId, setUpdatingId] = useState<string | null>(null);
+  const [successMessage, setSuccessMessage] = useState<string | null>(null);
+
+  useEffect(() => {
+    fetchAccessTiers();
+  }, []);
+
+  const fetchAccessTiers = async () => {
+    setIsLoading(true);
+    setError(null);
+    try {
+      const { data, error: apiError } = await apiClient.getAdminWalkthroughAccessTiers();
+      if (apiError) {
+        setError(apiError);
+        return;
+      }
+
+      const tiers = data?.access_tiers || {};
+
+      // Merge with static walkthrough data
+      const items: WalkthroughTierItem[] = WALKTHROUGHS_DATA.map((wt) => ({
+        id: wt.id,
+        title: wt.title,
+        difficulty: wt.difficulty,
+        accessTier: (tiers[wt.id] as 'FREE' | 'BUILDER') || 'FREE',
+      }));
+
+      setWalkthroughs(items);
+    } catch (err) {
+      setError(err instanceof Error ? err.message : 'Failed to fetch access tiers');
+    } finally {
+      setIsLoading(false);
+    }
+  };
+
+  const handleToggleTier = async (walkthroughId: string, currentTier: 'FREE' | 'BUILDER') => {
+    const newTier = currentTier === 'FREE' ? 'BUILDER' : 'FREE';
+    setUpdatingId(walkthroughId);
+    setError(null);
+    setSuccessMessage(null);
+
+    try {
+      const { error: apiError } = await apiClient.setWalkthroughAccessTier(walkthroughId, newTier);
+      if (apiError) {
+        setError(apiError);
+        return;
+      }
+
+      // Update local state
+      setWalkthroughs((prev) =>
+        prev.map((wt) =>
+          wt.id === walkthroughId ? { ...wt, accessTier: newTier } : wt
+        )
+      );
+
+      const wtTitle = walkthroughs.find((w) => w.id === walkthroughId)?.title || walkthroughId;
+      setSuccessMessage(`${wtTitle} set to ${newTier}`);
+      setTimeout(() => setSuccessMessage(null), 3000);
+    } catch (err) {
+      setError(err instanceof Error ? err.message : 'Failed to update access tier');
+    } finally {
+      setUpdatingId(null);
+    }
+  };
+
+  if (isLoading) {
+    return (
+      <div>
+        <h2 className="text-xl font-semibold text-gray-900 dark:text-gray-100 mb-4">
+          Walkthrough Access Tiers
+        </h2>
+        <div className="flex items-center justify-center py-12">
+          <Spinner size="lg" />
+        </div>
+      </div>
+    );
+  }
+
+  if (error && walkthroughs.length === 0) {
+    return (
+      <div>
+        <h2 className="text-xl font-semibold text-gray-900 dark:text-gray-100 mb-4">
+          Walkthrough Access Tiers
+        </h2>
+        <div className="bg-red-50 dark:bg-red-900/20 border border-red-200 dark:border-red-800 rounded-lg p-4">
+          <p className="text-sm text-red-800 dark:text-red-200">{error}</p>
+          <button
+            onClick={fetchAccessTiers}
+            className="mt-2 text-sm font-medium text-red-600 dark:text-red-400 hover:text-red-700"
+          >
+            Try Again
+          </button>
+        </div>
+      </div>
+    );
+  }
+
+  const lockedCount = walkthroughs.filter((w) => w.accessTier === 'BUILDER').length;
+
+  return (
+    <div>
+      <div className="flex items-center justify-between mb-4">
+        <div>
+          <h2 className="text-xl font-semibold text-gray-900 dark:text-gray-100">
+            Walkthrough Access Tiers
+          </h2>
+          <p className="text-sm text-gray-500 dark:text-gray-400 mt-1">
+            {lockedCount} of {walkthroughs.length} walkthroughs locked to Builder
+          </p>
+        </div>
+      </div>
+
+      {successMessage && (
+        <div className="mb-4 bg-green-50 dark:bg-green-900/20 border border-green-200 dark:border-green-800 rounded-lg px-4 py-2">
+          <p className="text-sm text-green-800 dark:text-green-200">{successMessage}</p>
+        </div>
+      )}
+
+      {error && walkthroughs.length > 0 && (
+        <div className="mb-4 bg-red-50 dark:bg-red-900/20 border border-red-200 dark:border-red-800 rounded-lg px-4 py-2">
+          <p className="text-sm text-red-800 dark:text-red-200">{error}</p>
+        </div>
+      )}
+
+      <div className="space-y-2">
+        {walkthroughs.map((wt) => (
+          <div
+            key={wt.id}
+            className="flex items-center justify-between rounded-lg border border-gray-200 dark:border-gray-700 px-4 py-3"
+          >
+            <div className="flex-1 min-w-0 mr-4">
+              <div className="text-sm font-medium text-gray-900 dark:text-gray-100 truncate">
+                {wt.title}
+              </div>
+              <div className="text-xs text-gray-500 dark:text-gray-400">
+                {wt.difficulty}
+              </div>
+            </div>
+            <button
+              onClick={() => handleToggleTier(wt.id, wt.accessTier)}
+              disabled={updatingId === wt.id}
+              className={`relative inline-flex h-7 w-14 flex-shrink-0 cursor-pointer rounded-full border-2 border-transparent transition-colors duration-200 ease-in-out focus:outline-none focus:ring-2 focus:ring-offset-2 disabled:opacity-50 ${
+                wt.accessTier === 'BUILDER'
+                  ? 'bg-amber-500 focus:ring-amber-500'
+                  : 'bg-gray-300 dark:bg-gray-600 focus:ring-gray-400'
+              }`}
+              role="switch"
+              aria-checked={wt.accessTier === 'BUILDER'}
+              aria-label={`Set ${wt.title} to ${wt.accessTier === 'BUILDER' ? 'FREE' : 'BUILDER'}`}
+            >
+              <span
+                className={`pointer-events-none inline-block h-6 w-6 transform rounded-full bg-white shadow ring-0 transition duration-200 ease-in-out ${
+                  wt.accessTier === 'BUILDER' ? 'translate-x-7' : 'translate-x-0'
+                }`}
+              />
+              <span className="absolute inset-0 flex items-center justify-center">
+                {updatingId === wt.id ? (
+                  <Spinner size="sm" />
+                ) : (
+                  <span
+                    className={`text-[10px] font-bold ${
+                      wt.accessTier === 'BUILDER'
+                        ? 'text-white ml-[-8px]'
+                        : 'text-gray-500 dark:text-gray-300 ml-[8px]'
+                    }`}
+                  >
+                    {wt.accessTier === 'BUILDER' ? '' : ''}
+                  </span>
+                )}
+              </span>
+            </button>
+            <span
+              className={`ml-3 text-xs font-semibold w-16 text-center ${
+                wt.accessTier === 'BUILDER'
+                  ? 'text-amber-700 dark:text-amber-400'
+                  : 'text-gray-500 dark:text-gray-400'
+              }`}
+            >
+              {wt.accessTier === 'BUILDER' ? 'Builder' : 'Free'}
+            </span>
+          </div>
+        ))}
+      </div>
+    </div>
+  );
+}

--- a/frontend/components/admin/WalkthroughAccessTiers.tsx
+++ b/frontend/components/admin/WalkthroughAccessTiers.tsx
@@ -1,6 +1,6 @@
 'use client';
 
-import { useEffect, useState } from 'react';
+import { useEffect, useState, useCallback } from 'react';
 import { apiClient } from '@/lib/api';
 import { WALKTHROUGHS_DATA } from '@/lib/walkthroughs-data';
 import { Spinner } from '@/components/ui/Spinner';
@@ -16,8 +16,7 @@ export function WalkthroughAccessTiers() {
   const [walkthroughs, setWalkthroughs] = useState<WalkthroughTierItem[]>([]);
   const [isLoading, setIsLoading] = useState(true);
   const [error, setError] = useState<string | null>(null);
-  const [updatingId, setUpdatingId] = useState<string | null>(null);
-  const [successMessage, setSuccessMessage] = useState<string | null>(null);
+  const [pendingIds, setPendingIds] = useState<Set<string>>(new Set());
 
   useEffect(() => {
     fetchAccessTiers();
@@ -35,7 +34,6 @@ export function WalkthroughAccessTiers() {
 
       const tiers = data?.access_tiers || {};
 
-      // Merge with static walkthrough data
       const items: WalkthroughTierItem[] = WALKTHROUGHS_DATA.map((wt) => ({
         id: wt.id,
         title: wt.title,
@@ -51,35 +49,42 @@ export function WalkthroughAccessTiers() {
     }
   };
 
-  const handleToggleTier = async (walkthroughId: string, currentTier: 'FREE' | 'BUILDER') => {
+  const handleToggleTier = useCallback(async (walkthroughId: string, currentTier: 'FREE' | 'BUILDER') => {
     const newTier = currentTier === 'FREE' ? 'BUILDER' : 'FREE';
-    setUpdatingId(walkthroughId);
-    setError(null);
-    setSuccessMessage(null);
+
+    // Optimistic update — toggle immediately for smooth UX
+    setWalkthroughs((prev) =>
+      prev.map((wt) =>
+        wt.id === walkthroughId ? { ...wt, accessTier: newTier } : wt
+      )
+    );
+    setPendingIds((prev) => new Set(prev).add(walkthroughId));
 
     try {
       const { error: apiError } = await apiClient.setWalkthroughAccessTier(walkthroughId, newTier);
       if (apiError) {
-        setError(apiError);
-        return;
+        // Revert on error
+        setWalkthroughs((prev) =>
+          prev.map((wt) =>
+            wt.id === walkthroughId ? { ...wt, accessTier: currentTier } : wt
+          )
+        );
       }
-
-      // Update local state
+    } catch {
+      // Revert on error
       setWalkthroughs((prev) =>
         prev.map((wt) =>
-          wt.id === walkthroughId ? { ...wt, accessTier: newTier } : wt
+          wt.id === walkthroughId ? { ...wt, accessTier: currentTier } : wt
         )
       );
-
-      const wtTitle = walkthroughs.find((w) => w.id === walkthroughId)?.title || walkthroughId;
-      setSuccessMessage(`${wtTitle} set to ${newTier}`);
-      setTimeout(() => setSuccessMessage(null), 3000);
-    } catch (err) {
-      setError(err instanceof Error ? err.message : 'Failed to update access tier');
     } finally {
-      setUpdatingId(null);
+      setPendingIds((prev) => {
+        const next = new Set(prev);
+        next.delete(walkthroughId);
+        return next;
+      });
     }
-  };
+  }, []);
 
   if (isLoading) {
     return (
@@ -128,76 +133,60 @@ export function WalkthroughAccessTiers() {
         </div>
       </div>
 
-      {successMessage && (
-        <div className="mb-4 bg-green-50 dark:bg-green-900/20 border border-green-200 dark:border-green-800 rounded-lg px-4 py-2">
-          <p className="text-sm text-green-800 dark:text-green-200">{successMessage}</p>
-        </div>
-      )}
-
-      {error && walkthroughs.length > 0 && (
-        <div className="mb-4 bg-red-50 dark:bg-red-900/20 border border-red-200 dark:border-red-800 rounded-lg px-4 py-2">
-          <p className="text-sm text-red-800 dark:text-red-200">{error}</p>
-        </div>
-      )}
-
       <div className="space-y-2">
-        {walkthroughs.map((wt) => (
-          <div
-            key={wt.id}
-            className="flex items-center justify-between rounded-lg border border-gray-200 dark:border-gray-700 px-4 py-3"
-          >
-            <div className="flex-1 min-w-0 mr-4">
-              <div className="text-sm font-medium text-gray-900 dark:text-gray-100 truncate">
-                {wt.title}
+        {walkthroughs.map((wt) => {
+          const isBuilder = wt.accessTier === 'BUILDER';
+          const isPending = pendingIds.has(wt.id);
+
+          return (
+            <div
+              key={wt.id}
+              className={`flex items-center justify-between rounded-lg border px-4 py-3 transition-colors duration-200 ${
+                isBuilder
+                  ? 'border-amber-200 dark:border-amber-800/50 bg-amber-50/50 dark:bg-amber-900/10'
+                  : 'border-gray-200 dark:border-gray-700'
+              }`}
+            >
+              <div className="flex-1 min-w-0 mr-4">
+                <div className="text-sm font-medium text-gray-900 dark:text-gray-100 truncate">
+                  {wt.title}
+                </div>
+                <div className="text-xs text-gray-500 dark:text-gray-400">
+                  {wt.difficulty}
+                </div>
               </div>
-              <div className="text-xs text-gray-500 dark:text-gray-400">
-                {wt.difficulty}
+              <div className="flex items-center gap-3">
+                <button
+                  onClick={() => handleToggleTier(wt.id, wt.accessTier)}
+                  disabled={isPending}
+                  className={`relative inline-flex h-6 w-11 flex-shrink-0 cursor-pointer rounded-full border-2 border-transparent transition-colors duration-200 ease-in-out focus:outline-none focus:ring-2 focus:ring-offset-2 focus:ring-amber-500 dark:focus:ring-offset-gray-900 disabled:cursor-wait ${
+                    isBuilder
+                      ? 'bg-amber-500'
+                      : 'bg-gray-300 dark:bg-gray-600'
+                  }`}
+                  role="switch"
+                  aria-checked={isBuilder}
+                  aria-label={`${wt.title}: ${isBuilder ? 'Builder (click to set Free)' : 'Free (click to set Builder)'}`}
+                >
+                  <span
+                    className={`pointer-events-none inline-block h-5 w-5 transform rounded-full bg-white shadow ring-0 transition-transform duration-200 ease-in-out ${
+                      isBuilder ? 'translate-x-5' : 'translate-x-0'
+                    }`}
+                  />
+                </button>
+                <span
+                  className={`text-xs font-semibold w-14 transition-colors duration-200 ${
+                    isBuilder
+                      ? 'text-amber-700 dark:text-amber-400'
+                      : 'text-gray-400 dark:text-gray-500'
+                  }`}
+                >
+                  {isBuilder ? 'Builder' : 'Free'}
+                </span>
               </div>
             </div>
-            <button
-              onClick={() => handleToggleTier(wt.id, wt.accessTier)}
-              disabled={updatingId === wt.id}
-              className={`relative inline-flex h-7 w-14 flex-shrink-0 cursor-pointer rounded-full border-2 border-transparent transition-colors duration-200 ease-in-out focus:outline-none focus:ring-2 focus:ring-offset-2 disabled:opacity-50 ${
-                wt.accessTier === 'BUILDER'
-                  ? 'bg-amber-500 focus:ring-amber-500'
-                  : 'bg-gray-300 dark:bg-gray-600 focus:ring-gray-400'
-              }`}
-              role="switch"
-              aria-checked={wt.accessTier === 'BUILDER'}
-              aria-label={`Set ${wt.title} to ${wt.accessTier === 'BUILDER' ? 'FREE' : 'BUILDER'}`}
-            >
-              <span
-                className={`pointer-events-none inline-block h-6 w-6 transform rounded-full bg-white shadow ring-0 transition duration-200 ease-in-out ${
-                  wt.accessTier === 'BUILDER' ? 'translate-x-7' : 'translate-x-0'
-                }`}
-              />
-              <span className="absolute inset-0 flex items-center justify-center">
-                {updatingId === wt.id ? (
-                  <Spinner size="sm" />
-                ) : (
-                  <span
-                    className={`text-[10px] font-bold ${
-                      wt.accessTier === 'BUILDER'
-                        ? 'text-white ml-[-8px]'
-                        : 'text-gray-500 dark:text-gray-300 ml-[8px]'
-                    }`}
-                  >
-                    {wt.accessTier === 'BUILDER' ? '' : ''}
-                  </span>
-                )}
-              </span>
-            </button>
-            <span
-              className={`ml-3 text-xs font-semibold w-16 text-center ${
-                wt.accessTier === 'BUILDER'
-                  ? 'text-amber-700 dark:text-amber-400'
-                  : 'text-gray-500 dark:text-gray-400'
-              }`}
-            >
-              {wt.accessTier === 'BUILDER' ? 'Builder' : 'Free'}
-            </span>
-          </div>
-        ))}
+          );
+        })}
       </div>
     </div>
   );

--- a/frontend/lib/api.ts
+++ b/frontend/lib/api.ts
@@ -10,7 +10,7 @@
  * All requests automatically include credentials (cookies) for JWT authentication.
  */
 
-import type { TestimonialRecord, PublicTestimonial, AdminTestimonial, ReviewData, NotificationData } from './types';
+import type { TestimonialRecord, PublicTestimonial, AdminTestimonial, ReviewData, NotificationData, ContributorRole, ContributorRoleName } from './types';
 
 const API_BASE_URL = process.env.NEXT_PUBLIC_API_URL || '';
 
@@ -95,6 +95,7 @@ export interface UserProfileResponse {
   last_login: string;
   is_new_user: boolean;
   total_completions: number;
+  contributor_role: ContributorRole | null;
 }
 
 /**
@@ -138,6 +139,7 @@ export interface UserListItem {
   avatar_url: string;
   registered_at: string;
   last_login: string;
+  contributor_role?: string | null;
 }
 
 /**
@@ -178,6 +180,7 @@ export interface AdminUserProfileResponse {
     started_at: string;
     completed_at?: string | null;
   }>;
+  contributor_role: ContributorRole | null;
 }
 
 /**
@@ -702,6 +705,38 @@ class ApiClient {
    */
   async getAdminUserProfile(userId: string): Promise<ApiResponse<AdminUserProfileResponse>> {
     return this.get<AdminUserProfileResponse>(`/admin/users/${encodeURIComponent(userId)}/profile`);
+  }
+
+  /**
+   * Get contributor role for a user (admin only)
+   *
+   * @param userId - The user ID to fetch contributor role for
+   * @returns Promise with contributor role data or null
+   */
+  async getContributorRole(userId: string): Promise<ApiResponse<{ contributor_role: ContributorRole | null }>> {
+    return this.get<{ contributor_role: ContributorRole | null }>(`/admin/users/${encodeURIComponent(userId)}/contributor-role`);
+  }
+
+  /**
+   * Assign or update a contributor role for a user (admin only)
+   *
+   * @param userId - The user ID to assign the role to
+   * @param role - The role to assign
+   * @param note - Optional note about the assignment
+   * @returns Promise with the assigned role data
+   */
+  async setContributorRole(userId: string, role: ContributorRoleName, note?: string): Promise<ApiResponse<{ message: string; contributor_role: ContributorRole }>> {
+    return this.put<{ message: string; contributor_role: ContributorRole }>(`/admin/users/${encodeURIComponent(userId)}/contributor-role`, { role, note: note || '' });
+  }
+
+  /**
+   * Remove a contributor role from a user (admin only)
+   *
+   * @param userId - The user ID to remove the role from
+   * @returns Promise with success message
+   */
+  async deleteContributorRole(userId: string): Promise<ApiResponse<{ message: string }>> {
+    return this.delete<{ message: string }>(`/admin/users/${encodeURIComponent(userId)}/contributor-role`);
   }
 
   /**

--- a/frontend/lib/api.ts
+++ b/frontend/lib/api.ts
@@ -10,7 +10,7 @@
  * All requests automatically include credentials (cookies) for JWT authentication.
  */
 
-import type { TestimonialRecord, PublicTestimonial, AdminTestimonial, ReviewData, NotificationData, ContributorRole, ContributorRoleName } from './types';
+import type { TestimonialRecord, PublicTestimonial, AdminTestimonial, ReviewData, NotificationData, ContributorRole, ContributorRoleName, BroadcastItem } from './types';
 
 const API_BASE_URL = process.env.NEXT_PUBLIC_API_URL || '';
 
@@ -737,6 +737,114 @@ class ApiClient {
    */
   async deleteContributorRole(userId: string): Promise<ApiResponse<{ message: string }>> {
     return this.delete<{ message: string }>(`/admin/users/${encodeURIComponent(userId)}/contributor-role`);
+  }
+
+  // ============================================================================
+  // Walkthrough Access Tier Methods
+  // ============================================================================
+
+  /**
+   * Get locked walkthrough IDs (authenticated user)
+   *
+   * Calls GET /api/walkthroughs/access-tiers to get walkthroughs that require BUILDER tier
+   *
+   * @returns Promise with access_tiers map (walkthrough_id -> "BUILDER")
+   */
+  async getWalkthroughAccessTiers(): Promise<ApiResponse<{ access_tiers: Record<string, string> }>> {
+    return this.get<{ access_tiers: Record<string, string> }>('/api/walkthroughs/access-tiers');
+  }
+
+  /**
+   * Get all walkthrough access tiers (admin only)
+   *
+   * @returns Promise with access_tiers map for all configured walkthroughs
+   */
+  async getAdminWalkthroughAccessTiers(): Promise<ApiResponse<{ access_tiers: Record<string, string> }>> {
+    return this.get<{ access_tiers: Record<string, string> }>('/admin/walkthroughs/access-tiers');
+  }
+
+  /**
+   * Set walkthrough access tier (admin only)
+   *
+   * @param walkthroughId - The walkthrough ID to configure
+   * @param accessTier - "FREE" or "BUILDER"
+   * @returns Promise with success message
+   */
+  async setWalkthroughAccessTier(walkthroughId: string, accessTier: 'FREE' | 'BUILDER'): Promise<ApiResponse<{ message: string; data: { walkthrough_id: string; access_tier: string; set_by: string; updated_at: string } }>> {
+    return this.put<{ message: string; data: { walkthrough_id: string; access_tier: string; set_by: string; updated_at: string } }>(`/admin/walkthroughs/${encodeURIComponent(walkthroughId)}/access-tier`, { access_tier: accessTier });
+  }
+
+  /**
+   * Reset walkthrough access tier to FREE (admin only)
+   *
+   * @param walkthroughId - The walkthrough ID to unlock
+   * @returns Promise with success message
+   */
+  async deleteWalkthroughAccessTier(walkthroughId: string): Promise<ApiResponse<{ message: string }>> {
+    return this.delete<{ message: string }>(`/admin/walkthroughs/${encodeURIComponent(walkthroughId)}/access-tier`);
+  }
+
+  // ============================================================================
+  // Broadcast Notification Methods
+  // ============================================================================
+
+  /**
+   * Get unread broadcasts for the authenticated user
+   *
+   * @returns Promise with list of unread broadcasts (oldest first)
+   */
+  async getUnreadBroadcasts(): Promise<ApiResponse<{ broadcasts: BroadcastItem[] }>> {
+    return this.get<{ broadcasts: BroadcastItem[] }>('/api/broadcasts/unread');
+  }
+
+  /**
+   * Dismiss a single broadcast
+   *
+   * @param broadcastId - The broadcast ID to dismiss
+   * @returns Promise with success message
+   */
+  async dismissBroadcast(broadcastId: string): Promise<ApiResponse<{ message: string }>> {
+    return this.post<{ message: string }>(`/api/broadcasts/${encodeURIComponent(broadcastId)}/dismiss`, {});
+  }
+
+  /**
+   * Dismiss all unread broadcasts
+   *
+   * @returns Promise with success message
+   */
+  async dismissAllBroadcasts(): Promise<ApiResponse<{ message: string }>> {
+    return this.post<{ message: string }>('/api/broadcasts/dismiss-all', {});
+  }
+
+  /**
+   * Create a broadcast notification (admin only)
+   *
+   * @param title - Broadcast title (max 100 chars)
+   * @param message - Markdown message body (max 2000 chars)
+   * @param link - Optional CTA URL
+   * @returns Promise with created broadcast data
+   */
+  async createBroadcast(title: string, message: string, link?: string): Promise<ApiResponse<{ message: string; broadcast: BroadcastItem }>> {
+    return this.post<{ message: string; broadcast: BroadcastItem }>('/admin/broadcasts', { title, message, link: link || '' });
+  }
+
+  /**
+   * Get all broadcasts (admin only)
+   *
+   * @returns Promise with list of all broadcasts
+   */
+  async getAdminBroadcasts(): Promise<ApiResponse<{ broadcasts: BroadcastItem[] }>> {
+    return this.get<{ broadcasts: BroadcastItem[] }>('/admin/broadcasts');
+  }
+
+  /**
+   * Delete a broadcast (admin only)
+   *
+   * @param broadcastId - The broadcast ID to delete
+   * @returns Promise with success message
+   */
+  async deleteBroadcast(broadcastId: string): Promise<ApiResponse<{ message: string }>> {
+    return this.delete<{ message: string }>(`/admin/broadcasts/${encodeURIComponent(broadcastId)}`);
   }
 
   /**

--- a/frontend/lib/data/plans.ts
+++ b/frontend/lib/data/plans.ts
@@ -56,7 +56,7 @@ export const SUBSCRIPTION_COMPARISONS: ComparisonItem[] = [
   {
     name: "DSB Builder",
     description: "Hands-on DevSecOps projects, guided walkthroughs, and group support",
-    price: "$29/mo",
+    price: "$29.99/mo",
     priceNote: "Cancel anytime",
   },
   {

--- a/frontend/lib/types.ts
+++ b/frontend/lib/types.ts
@@ -233,6 +233,16 @@ export interface ReviewData {
   updated_at: string;
 }
 
+// Contributor Role types
+export type ContributorRoleName = 'contributor';
+
+export interface ContributorRole {
+  role: ContributorRoleName;
+  assigned_by: string;
+  assigned_at: string;
+  note: string;
+}
+
 // Notification types
 export interface NotificationData {
   notification_id: string;

--- a/frontend/lib/types.ts
+++ b/frontend/lib/types.ts
@@ -250,3 +250,13 @@ export interface NotificationData {
   link: string;
   created_at: string;
 }
+
+// Broadcast types
+export interface BroadcastItem {
+  broadcast_id: string;
+  title: string;
+  message: string;
+  link: string;
+  created_by: string;
+  created_at: string;
+}

--- a/tasks.py
+++ b/tasks.py
@@ -48,7 +48,7 @@ def build_image(ctx, tag="latest"):
     print("Building Docker Image")
     print("=" * 60)
     ctx.run(
-        f"docker build --platform linux/amd64,linux/arm64 -t {ECR_REPO}:{tag} backend/",
+        f"docker build -t {ECR_REPO}:{tag} backend/",
         pty=True,
     )
     print(f"\n✅ Docker image built: {ECR_REPO}:{tag}")

--- a/terraform/main.tf
+++ b/terraform/main.tf
@@ -366,7 +366,8 @@ module "iam_ecs" {
     module.dynamodb.user_state_table_arn,
     module.dynamodb_membership.table_arn,
     module.dynamodb.testimonials_table_arn,
-    module.dynamodb.notifications_table_arn
+    module.dynamodb.notifications_table_arn,
+    module.dynamodb.broadcasts_table_arn
   ]
   secrets_arns = [
     module.github_oauth.secret_arn,
@@ -425,6 +426,7 @@ module "ecs" {
     TESTIMONIAL_NOTIFY_EMAIL     = "info@devsecblueprint.com"
     TESTIMONIALS_TABLE           = module.dynamodb.testimonials_table_name
     NOTIFICATIONS_TABLE          = module.dynamodb.notifications_table_name
+    BROADCASTS_TABLE             = module.dynamodb.broadcasts_table_name
 
     # From dsb-platform-membership Lambda
     MEMBERSHIP_TABLE                = module.dynamodb_membership.table_name

--- a/terraform/main.tf
+++ b/terraform/main.tf
@@ -104,12 +104,13 @@ module "jwt_secret" {
   tags = var.common_tags
 }
 
-# SSM Parameter Store for Mailgun API key
+# SSM Parameter Store for Mailgun API key (deprecated — kept for state compatibility)
+# TODO: Remove after confirming SES migration is stable
 module "mailgun_api_key" {
   source = "./modules/ssm_parameter"
 
   parameter_name        = "/app/mailgun/api-key"
-  parameter_description = "Mailgun API key for sending emails"
+  parameter_description = "Mailgun API key (deprecated - migrated to SES)"
   parameter_value       = var.TFC_MAILGUN_API_KEY
 
   tags = var.common_tags
@@ -287,42 +288,62 @@ resource "aws_route53_record" "shop" {
   records = ["cdn.myspreadshop.com"]
 }
 
-# Mailgun
-resource "aws_route53_record" "mg_include_all" {
+# SES custom MAIL FROM records
+resource "aws_route53_record" "ses_mail_from_mx" {
   count   = local.is_dsb_platform ? 1 : 0
   zone_id = module.route53.zone_id
-  name    = "mg.devsecblueprint.com"
-  type    = "TXT"
-  ttl     = 300
-  records = ["v=spf1 include:mailgun.org ~all"]
-}
-
-resource "aws_route53_record" "mx_domainkey_txt" {
-  count   = local.is_dsb_platform ? 1 : 0
-  zone_id = module.route53.zone_id
-  name    = "mx._domainkey.mg.devsecblueprint.com"
-  type    = "TXT"
-  ttl     = 300
-  records = ["k=rsa; p=MIGfMA0GCSqGSIb3DQEBAQUAA4GNADCBiQKBgQCn3BIAsfWUNEy2OOGqrDpsQLx0ryELBtB3YNEKPu0ZuNhDS/qZrfYPCAzxmjchoIsq4Vp9inxYIzr4aMjyuZzYW2KQOPo0qS6NzvB/9hYY4y95XnM5gXg+JD74XoBao14siKwTvzVTiQVrssgvOhvuewqZfapOiQ4A7eDhCbAbkQIDAQAB"]
-}
-
-resource "aws_route53_record" "mg_mx" {
-  count   = local.is_dsb_platform ? 1 : 0
-  zone_id = module.route53.zone_id
-  name    = "mg.devsecblueprint.com"
+  name    = "noreply.devsecblueprint.com"
   type    = "MX"
   ttl     = 300
-  records = ["10 mxa.mailgun.org", "50 mxb.mailgun.org"]
+  records = ["10 feedback-smtp.us-east-2.amazonses.com"]
 }
 
-resource "aws_route53_record" "mg_email_domain" {
+resource "aws_route53_record" "ses_mail_from_spf" {
   count   = local.is_dsb_platform ? 1 : 0
   zone_id = module.route53.zone_id
-  name    = "email.mg.devsecblueprint.com"
+  name    = "noreply.devsecblueprint.com"
+  type    = "TXT"
+  ttl     = 300
+  records = ["v=spf1 include:amazonses.com ~all"]
+}
+
+# SES DKIM verification records
+resource "aws_route53_record" "ses_dkim_1" {
+  count   = local.is_dsb_platform ? 1 : 0
+  zone_id = module.route53.zone_id
+  name    = "4p7hvxg7dpj2ler6di3vqnajanvvxgh5._domainkey.devsecblueprint.com"
   type    = "CNAME"
   ttl     = 300
-  records = ["mailgun.org"]
+  records = ["4p7hvxg7dpj2ler6di3vqnajanvvxgh5.dkim.amazonses.com"]
 }
+
+resource "aws_route53_record" "ses_dkim_2" {
+  count   = local.is_dsb_platform ? 1 : 0
+  zone_id = module.route53.zone_id
+  name    = "tsclevsy2zi6mibg7pj6gak4x7ltpyxi._domainkey.devsecblueprint.com"
+  type    = "CNAME"
+  ttl     = 300
+  records = ["tsclevsy2zi6mibg7pj6gak4x7ltpyxi.dkim.amazonses.com"]
+}
+
+resource "aws_route53_record" "ses_dkim_3" {
+  count   = local.is_dsb_platform ? 1 : 0
+  zone_id = module.route53.zone_id
+  name    = "gzhv3ewjnhvvyynx2r46phdy5bgkmxbt._domainkey.devsecblueprint.com"
+  type    = "CNAME"
+  ttl     = 300
+  records = ["gzhv3ewjnhvvyynx2r46phdy5bgkmxbt.dkim.amazonses.com"]
+}
+
+resource "aws_route53_record" "dmarc" {
+  count   = local.is_dsb_platform ? 1 : 0
+  zone_id = module.route53.zone_id
+  name    = "_dmarc.devsecblueprint.com"
+  type    = "TXT"
+  ttl     = 300
+  records = ["v=DMARC1; p=none;"]
+}
+
 
 # =============================================================================
 # ALB for ECS Fargate service
@@ -421,8 +442,8 @@ module "ecs" {
     FRONTEND_ORIGIN              = "https://${var.TFC_FRONTEND_DOMAIN}"
     CONTENT_REGISTRY_BUCKET      = module.s3_content_registry.bucket_name
     TOTAL_MODULE_PAGES           = tostring(var.total_module_pages)
-    MAILGUN_DOMAIN               = var.mailgun_domain
-    MAILGUN_PARAM_NAME           = module.mailgun_api_key.parameter_name
+    SES_SENDER_EMAIL             = "noreply@devsecblueprint.com"
+    SES_REGION                   = "us-east-2"
     TESTIMONIAL_NOTIFY_EMAIL     = "info@devsecblueprint.com"
     TESTIMONIALS_TABLE           = module.dynamodb.testimonials_table_name
     NOTIFICATIONS_TABLE          = module.dynamodb.notifications_table_name

--- a/terraform/modules/dynamodb/main.tf
+++ b/terraform/modules/dynamodb/main.tf
@@ -92,6 +92,38 @@ resource "aws_dynamodb_table" "notifications" {
   tags = var.tags
 }
 
+resource "aws_dynamodb_table" "broadcasts" {
+  name         = var.broadcasts_table_name
+  billing_mode = "PAY_PER_REQUEST"
+  hash_key     = "PK"
+  range_key    = "SK"
+
+  attribute {
+    name = "PK"
+    type = "S"
+  }
+
+  attribute {
+    name = "SK"
+    type = "S"
+  }
+
+  server_side_encryption {
+    enabled = true
+  }
+
+  point_in_time_recovery {
+    enabled = true
+  }
+
+  ttl {
+    attribute_name = "ttl"
+    enabled        = true
+  }
+
+  tags = var.tags
+}
+
 resource "aws_dynamodb_table" "testimonials" {
   name         = var.testimonials_table_name
   billing_mode = "PAY_PER_REQUEST"

--- a/terraform/modules/dynamodb/outputs.tf
+++ b/terraform/modules/dynamodb/outputs.tf
@@ -37,3 +37,13 @@ output "notifications_table_arn" {
   description = "Notifications table ARN"
   value       = aws_dynamodb_table.notifications.arn
 }
+
+output "broadcasts_table_name" {
+  description = "Broadcasts table name"
+  value       = aws_dynamodb_table.broadcasts.name
+}
+
+output "broadcasts_table_arn" {
+  description = "Broadcasts table ARN"
+  value       = aws_dynamodb_table.broadcasts.arn
+}

--- a/terraform/modules/dynamodb/variables.tf
+++ b/terraform/modules/dynamodb/variables.tf
@@ -21,6 +21,12 @@ variable "notifications_table_name" {
   default     = "dsb-platform-notifications"
 }
 
+variable "broadcasts_table_name" {
+  description = "Name for the Broadcasts DynamoDB table"
+  type        = string
+  default     = "dsb-platform-broadcasts"
+}
+
 variable "tags" {
   description = "Tags to apply to DynamoDB tables"
   type        = map(string)

--- a/terraform/modules/iam_ecs/main.tf
+++ b/terraform/modules/iam_ecs/main.tf
@@ -176,3 +176,23 @@ resource "aws_iam_role_policy" "ecs_task_ssm" {
     ]
   })
 }
+
+# SES access for sending emails
+resource "aws_iam_role_policy" "ecs_task_ses" {
+  name = "${var.project_name}-ecs-task-ses"
+  role = aws_iam_role.ecs_task.id
+
+  policy = jsonencode({
+    Version = "2012-10-17"
+    Statement = [
+      {
+        Effect = "Allow"
+        Action = [
+          "ses:SendEmail",
+          "ses:SendRawEmail"
+        ]
+        Resource = "*"
+      }
+    ]
+  })
+}


### PR DESCRIPTION


## Summary

Major platform feature release adding contributor mapping, walkthrough paywall (FREE/Builder tiers), admin broadcast notifications with email delivery, and email infrastructure migration from Mailgun to AWS SES.

## Changes

### Contributor Role Mapping
- Admin can assign/remove "Contributor" role to users via the user profile modal
- Role displays on the user's dashboard and in the admin user list
- Backend: DynamoDB record `PK: USER#{id}`, `SK: CONTRIBUTOR_ROLE` in progress table
- Endpoints: `GET/PUT/DELETE /admin/users/{id}/contributor-role`

### Walkthrough Paywall (FREE/Builder Tiers)
- Admin can lock walkthroughs behind Builder subscription via toggle UI on admin dashboard
- FREE users see lock icon on walkthrough cards and an upgrade prompt on the detail page
- Backend enforces tier check on progress updates (403 if FREE user attempts Builder walkthrough)
- Backend: DynamoDB record `PK: WALKTHROUGH_ACCESS`, `SK: WT#{id}` in progress table
- Endpoints: `GET/PUT/DELETE /admin/walkthroughs/{id}/access-tier`, `GET /api/walkthroughs/access-tiers`

### Admin Broadcast Notifications
- Admin composes broadcasts (title + markdown body + optional link) from the admin dashboard
- Broadcasts display as a stacked modal on the user's dashboard upon login (dismiss one-at-a-time or all)
- Email sent to all users with registered email addresses via background task
- Broadcasts auto-expire after 90 days (DynamoDB TTL)
- Dedicated `BROADCASTS_TABLE` DynamoDB table
- Endpoints: `POST/GET/DELETE /admin/broadcasts`, `GET /api/broadcasts/unread`, `POST /api/broadcasts/{id}/dismiss`, `POST /api/broadcasts/dismiss-all`

### Email Migration: Mailgun to AWS SES
- Replaced Mailgun HTTP API with `boto3` SES client (`ses:SendEmail`)
- No API keys needed — uses ECS task role IAM permissions
- Config: `ses_sender_email` + `ses_region` replace `mailgun_domain` + `mailgun_param_name`
- Removed `requests` pip dependency
- Added SES IAM policy to ECS task role
- DNS: Removed Mailgun records, added SES DKIM CNAMEs + custom MAIL FROM (MX + SPF)
- Broadcast email template improved with inline CSS typography, personalized greeting, and proper markdown rendering

### Code Quality
- Removed all inline imports from `admin.py` and `content.py` — all imports at module level per PEP 8

## Infrastructure Changes (Terraform)

- New DynamoDB table: `dsb-platform-broadcasts` (PK/SK String, TTL on `ttl`, PAY_PER_REQUEST)
- IAM: Added `ses:SendEmail`/`ses:SendRawEmail` to ECS task role
- DNS: 3 SES DKIM CNAMEs, 1 MAIL FROM MX, 1 MAIL FROM SPF TXT added; 4 Mailgun records removed
- ECS env vars: Added `BROADCASTS_TABLE`, `SES_SENDER_EMAIL`, `SES_REGION`; removed `MAILGUN_DOMAIN`, `MAILGUN_PARAM_NAME`

## Deployment Notes

1. Run `terraform apply` to create the broadcasts table, update IAM, and update DNS
2. Verify SES domain identity is confirmed in us-east-2 (DKIM records must propagate)
3. If in SES sandbox, request production access before sending to unverified addresses
4. Deploy new backend image (includes `markdown==3.7` dependency, removes `requests`)
5. Add `BROADCASTS_TABLE=dsb-platform-broadcasts` to any local `.env` files