### PR TITLE
feat: Add Career Strategy Section + Broadcast Notifications

### DIFF
--- a/backend/app/services/badge_service.py
+++ b/backend/app/services/badge_service.py
@@ -120,6 +120,20 @@ PATH_PAGE_IDS: dict[str, set[str]] = {
         "the-blueprint-library-iac-security",
         "cloud_security_development-capstone",
     },
+    "career_strategy": {
+        "career-strategy-overview",
+        "the-psychology-of-the-job-search",
+        "applying-with-intention",
+        "understanding-what-companies-are-really-evaluating",
+        "interview-mindset-and-communication",
+        "questions-to-ask-in-interviews",
+        "questions-to-avoid-or-reframe",
+        "certifications-and-market-signals",
+        "resume-positioning",
+        "networking-basics",
+        "finding-a-culture-that-aligns-with-your-values",
+        "learning-from-rejection",
+    },
 }
 
 # Badge definitions
@@ -197,12 +211,20 @@ BADGE_DEFINITIONS: list[dict[str, Any]] = [
         "threshold": 1,
     },
     {
+        "id": "b11",
+        "title": "Career Strategist",
+        "description": "Complete Career Strategy path",
+        "icon": "🧭",
+        "criteria": "path_completion",
+        "threshold": "career_strategy",
+    },
+    {
         "id": "b10",
         "title": "Completionist",
         "description": "Earn all other badges",
         "icon": "👑",
         "criteria": "all_badges",
-        "threshold": 9,
+        "threshold": 10,
     },
 ]
 

--- a/frontend/app/page.tsx
+++ b/frontend/app/page.tsx
@@ -40,7 +40,7 @@ export default function Home() {
           
           {/* Header Text */}
           <h1 className="text-lg sm:text-xl md:text-2xl font-normal text-gray-700 dark:text-gray-300 leading-relaxed max-w-3xl mx-auto">
-            A comprehensive, open-source roadmap to mastering DevSecOps and Cloud Security Development. Learn the foundations, build secure systems, and gain real-world engineering experience through structured, hands-on practice.
+            Master DevSecOps and Cloud Security through real-world engineering. Learn the fundamentals, build production-ready projects, and grow your career through structured learning, hands-on implementation, and an engaged community.
           </h1>
           
           {/* CTA Button */}

--- a/frontend/components/features/curriculum/CurriculumHero.tsx
+++ b/frontend/components/features/curriculum/CurriculumHero.tsx
@@ -6,11 +6,11 @@ export function CurriculumHero() {
           DevSec Blueprint Curriculum
         </h1>
         <p className="text-lg sm:text-xl text-gray-700 dark:text-gray-300">
-          A hands-on learning roadmap for DevSecOps and Cloud Security engineering skills
+          A structured learning path for DevSecOps, Cloud Security engineering, and career growth
         </p>
         <p className="text-base sm:text-lg text-gray-600 dark:text-gray-400 max-w-3xl mx-auto">
-          This curriculum focuses on real-world engineering skills, not certification theory. 
-          Build secure systems through structured, practical learning.
+          From secure pipelines and cloud architecture to career strategy and interview preparation. 
+          Build real skills, ship secure systems, and position yourself for the roles you actually want.
         </p>
       </div>
     </section>

--- a/frontend/lib/constants.ts
+++ b/frontend/lib/constants.ts
@@ -42,6 +42,13 @@ export const LEARNING_PATHS: LearningPath[] = [
     description: 'Capstones are where you bring everything together. These larger, end-to-end projects are designed to test how well you can apply what you\'ve learned across multiple areas, from secure pipelines to cloud architecture and security controls. The goal is to move beyond isolated exercises and demonstrate real-world problem solving through practical implementation.',
     slug: 'capstones',
     moduleCount: 0
+  },
+  {
+    id: '7',
+    title: 'Career Strategy',
+    description: 'Navigate the career side of cloud security and DevSecOps with intention. This path covers job search psychology, resume positioning, interview communication, networking, certifications as market signals, and how to evaluate whether a role and culture actually fit how you work best.',
+    slug: 'career-strategy',
+    moduleCount: 12
   }
 ];
 

--- a/frontend/lib/curriculum-data.ts
+++ b/frontend/lib/curriculum-data.ts
@@ -55,7 +55,7 @@ export const CURRICULUM_STAGES: CurriculumStage[] = [
     id: 'stage-2',
     name: 'DevSecOps',
     description: 'Integrating security into the development lifecycle',
-    moduleCount: 6,
+    moduleCount: 7,
     stageNumber: 2,
     modules: [
       {
@@ -134,6 +134,17 @@ export const CURRICULUM_STAGES: CurriculumStage[] = [
           'Runtime protection concepts',
           'Build, ship, and run security'
         ]
+      },
+      {
+        id: 'module-2-7',
+        name: 'DevSecOps Capstone',
+        description: 'Apply everything from the DevSecOps path in a real-world engineering scenario',
+        topics: [
+          'Build an automated security pipeline',
+          'Integrate SAST, DAST, and SCA into CI/CD',
+          'Implement policy gates and security controls',
+          'End-to-end secure delivery workflow'
+        ]
       }
     ]
   },
@@ -141,7 +152,7 @@ export const CURRICULUM_STAGES: CurriculumStage[] = [
     id: 'stage-3',
     name: 'Cloud Security Development',
     description: 'Building secure applications in the cloud',
-    moduleCount: 7,
+    moduleCount: 8,
     stageNumber: 2,
     modules: [
       {
@@ -227,17 +238,44 @@ export const CURRICULUM_STAGES: CurriculumStage[] = [
           'Policy enforcement',
           'Infrastructure scanning'
         ]
+      },
+      {
+        id: 'module-3-8',
+        name: 'Cloud Security Development Capstone',
+        description: 'Apply everything from the Cloud Security Development path in a real-world engineering scenario',
+        topics: [
+          'Build a self-healing cloud environment',
+          'Implement cloud-native detection and response',
+          'Design multi-account security architecture',
+          'End-to-end cloud security automation'
+        ]
       }
     ]
   },
   {
     id: 'stage-4',
-    name: 'Capstone Projects',
-    description: 'Apply everything you\'ve learned through real-world engineering scenarios. Build complete systems with security integrated from design through deployment.',
+    name: 'Career Strategy',
+    description: 'Navigating the career side of cloud security and DevSecOps with strategy, self-awareness, and intention',
+    moduleCount: 1,
     stageNumber: 3,
-    projects: [
-      'DevSecOps Capstone: Build an automated security pipeline',
-      'Cloud Security Development Capstone: Build a self-healing cloud environment'
+    modules: [
+      {
+        id: 'module-4-1',
+        name: 'Career Strategy',
+        description: 'A comprehensive guide to positioning yourself strategically in the cloud security and DevSecOps job market',
+        topics: [
+          'Job search psychology and mindset',
+          'Intentional application strategy',
+          'Understanding what companies evaluate',
+          'Interview communication and framing',
+          'Strategic questions to ask (and avoid)',
+          'Certifications as market signals',
+          'Resume positioning',
+          'Networking without being transactional',
+          'Finding culture alignment',
+          'Learning from rejection'
+        ]
+      }
     ]
   }
 ];

--- a/frontend/lib/data/modules.json
+++ b/frontend/lib/data/modules.json
@@ -493,10 +493,109 @@
     ]
   },
   {
+    "id": "career_strategy/career_strategy",
+    "title": "Career Strategy",
+    "learningPath": "Career Strategy",
+    "order": 11,
+    "pages": [
+      {
+        "id": "career-strategy-overview",
+        "title": "Career Strategy Overview",
+        "slug": "/learn/career_strategy/module_01",
+        "order": 1,
+        "completed": false
+      },
+      {
+        "id": "the-psychology-of-the-job-search",
+        "title": "The Psychology of the Job Search",
+        "slug": "/learn/career_strategy/module_02",
+        "order": 2,
+        "completed": false
+      },
+      {
+        "id": "applying-with-intention",
+        "title": "Applying With Intention",
+        "slug": "/learn/career_strategy/module_03",
+        "order": 3,
+        "completed": false
+      },
+      {
+        "id": "understanding-what-companies-are-really-evaluating",
+        "title": "Understanding What Companies Are Really Evaluating",
+        "slug": "/learn/career_strategy/module_04",
+        "order": 4,
+        "completed": false
+      },
+      {
+        "id": "interview-mindset-and-communication",
+        "title": "Interview Mindset and Communication",
+        "slug": "/learn/career_strategy/module_05",
+        "order": 5,
+        "completed": false
+      },
+      {
+        "id": "questions-to-ask-in-interviews",
+        "title": "Questions to Ask in Interviews",
+        "slug": "/learn/career_strategy/module_06",
+        "order": 6,
+        "completed": false
+      },
+      {
+        "id": "questions-to-avoid-or-reframe",
+        "title": "Questions to Avoid or Reframe",
+        "slug": "/learn/career_strategy/module_07",
+        "order": 7,
+        "completed": false
+      },
+      {
+        "id": "certifications-and-market-signals",
+        "title": "Certifications and Market Signals",
+        "slug": "/learn/career_strategy/module_08",
+        "order": 8,
+        "completed": false
+      },
+      {
+        "id": "resume-positioning",
+        "title": "Resume Positioning",
+        "slug": "/learn/career_strategy/module_09",
+        "order": 9,
+        "completed": false
+      },
+      {
+        "id": "networking-basics",
+        "title": "Networking Basics",
+        "slug": "/learn/career_strategy/module_10",
+        "order": 10,
+        "completed": false
+      },
+      {
+        "id": "finding-a-culture-that-aligns-with-your-values",
+        "title": "Finding a Culture That Aligns With Your Values",
+        "slug": "/learn/career_strategy/module_11",
+        "order": 11,
+        "completed": false
+      },
+      {
+        "id": "learning-from-rejection",
+        "title": "Learning From Rejection",
+        "slug": "/learn/career_strategy/module_12",
+        "order": 12,
+        "completed": false
+      },
+      {
+        "id": "career-books-and-reference-material",
+        "title": "Career Books and Reference Material",
+        "slug": "/learn/career_strategy/module_13",
+        "order": 13,
+        "completed": false
+      }
+    ]
+  },
+  {
     "id": "cloud_security_development/what_is_cloud_security_development",
     "title": "What is Cloud Security Development?",
     "learningPath": "Cloud Security Development",
-    "order": 11,
+    "order": 12,
     "pages": [
       {
         "id": "the-bridge-cloud-security-development",
@@ -532,7 +631,7 @@
     "id": "cloud_security_development/iam_fundamentals",
     "title": "IAM Fundamentals",
     "learningPath": "Cloud Security Development",
-    "order": 12,
+    "order": 13,
     "pages": [
       {
         "id": "the-gatekeeper-iam-fundamentals",
@@ -582,7 +681,7 @@
     "id": "cloud_security_development/api_patterns_and_sdks",
     "title": "API Patterns and SDKs",
     "learningPath": "Cloud Security Development",
-    "order": 13,
+    "order": 14,
     "pages": [
       {
         "id": "the-control-plane-api-patterns",
@@ -625,7 +724,7 @@
     "id": "cloud_security_development/secrets_management_in_the_cloud",
     "title": "Secrets Management In The Cloud",
     "learningPath": "Cloud Security Development",
-    "order": 14,
+    "order": 15,
     "pages": [
       {
         "id": "the-vault-secrets-and-config",
@@ -675,7 +774,7 @@
     "id": "cloud_security_development/cloud_logging_and_monitoring",
     "title": "Cloud Logging and Monitoring",
     "learningPath": "Cloud Security Development",
-    "order": 15,
+    "order": 16,
     "pages": [
       {
         "id": "the-observability-layer-logging-events",
@@ -725,7 +824,7 @@
     "id": "cloud_security_development/serverless",
     "title": "Serverless",
     "learningPath": "Cloud Security Development",
-    "order": 16,
+    "order": 17,
     "pages": [
       {
         "id": "the-automated-conductor-serverless-orchestration",
@@ -775,7 +874,7 @@
     "id": "cloud_security_development/iac_security",
     "title": "IaC Security",
     "learningPath": "Cloud Security Development",
-    "order": 17,
+    "order": 18,
     "pages": [
       {
         "id": "the-conveyor-belt-iac-security",
@@ -825,7 +924,7 @@
     "id": "cloud_security_development/capstone",
     "title": "Cloud Security Development Capstone Project",
     "learningPath": "Cloud Security Development",
-    "order": 18,
+    "order": 19,
     "pages": [
       {
         "id": "cloud_security_development-capstone",

--- a/frontend/scripts/generate-content-registry.ts
+++ b/frontend/scripts/generate-content-registry.ts
@@ -76,6 +76,7 @@ async function discoverQuizFiles(basePath: string = 'content'): Promise<ContentF
       
       // Extract learning path and topic from file path
       // Pattern: content/{learning_path}/{topic}/quiz.md
+      // Or direct: content/{learning_path}/quiz.md (topic = learning_path)
       const pathParts = filePath.split(path.sep);
       const contentIndex = pathParts.indexOf('content');
       
@@ -84,7 +85,13 @@ async function discoverQuizFiles(basePath: string = 'content'): Promise<ContentF
       
       if (contentIndex >= 0 && pathParts.length > contentIndex + 2) {
         learningPath = pathParts[contentIndex + 1];
-        topic = pathParts[contentIndex + 2];
+        const candidate = pathParts[contentIndex + 2];
+        // If the candidate is quiz.md itself, this is a direct-file learning path
+        if (candidate === 'quiz.md') {
+          topic = learningPath;
+        } else {
+          topic = candidate;
+        }
       }
       
       return {
@@ -175,6 +182,7 @@ async function discoverModuleFiles(basePath: string = 'content'): Promise<Conten
 
       // Extract learning path and topic from file path
       // Pattern: content/{learning_path}/{topic}/module_N.md
+      // Or direct: content/{learning_path}/module_N.md (topic = learning_path)
       const pathParts = filePath.split(path.sep);
       const contentIndex = pathParts.indexOf('content');
 
@@ -183,7 +191,13 @@ async function discoverModuleFiles(basePath: string = 'content'): Promise<Conten
 
       if (contentIndex >= 0 && pathParts.length > contentIndex + 2) {
         learningPath = pathParts[contentIndex + 1];
-        topic = pathParts[contentIndex + 2];
+        const candidate = pathParts[contentIndex + 2];
+        // If the candidate is the file itself (ends with .md), this is a direct-file learning path
+        if (candidate.endsWith('.md')) {
+          topic = learningPath;
+        } else {
+          topic = candidate;
+        }
       }
 
       return {
@@ -1110,6 +1124,7 @@ async function parseModuleFile(filePath: string): Promise<ModuleEntry> {
 
     // Extract learning path and topic from file path
     // Pattern: content/{learning_path}/{topic}/module_N.md
+    // Or direct: content/{learning_path}/module_N.md (topic = learning_path)
     const pathParts = filePath.split(path.sep);
     const contentIndex = pathParts.indexOf('content');
 
@@ -1120,7 +1135,10 @@ async function parseModuleFile(filePath: string): Promise<ModuleEntry> {
     }
 
     const learningPath = pathParts[contentIndex + 1];
-    const topic = pathParts[contentIndex + 2];
+    const candidate = pathParts[contentIndex + 2];
+
+    // If the candidate is the file itself (ends with .md), this is a direct-file learning path
+    const topic = candidate.endsWith('.md') ? learningPath : candidate;
 
     // Construct module_id
     const moduleId = `${learningPath}/${topic}`;
@@ -1513,6 +1531,7 @@ async function parseQuizFile(filePath: string): Promise<QuizEntry> {
 
     // Extract learning path and topic from file path if module_id doesn't include it
     // Pattern: content/{learning_path}/{topic}/quiz.md
+    // Or direct: content/{learning_path}/quiz.md
     let moduleId = frontmatter.module_id;
     
     if (!moduleId.includes('/')) {
@@ -1522,8 +1541,13 @@ async function parseQuizFile(filePath: string): Promise<QuizEntry> {
       
       if (contentIndex >= 0 && pathParts.length > contentIndex + 2) {
         const learningPath = pathParts[contentIndex + 1];
-        const topic = pathParts[contentIndex + 2];
-        moduleId = `${learningPath}/${topic}`;
+        const candidate = pathParts[contentIndex + 2];
+        // If candidate is quiz.md, this is a direct-file learning path
+        if (candidate === 'quiz.md') {
+          moduleId = `${learningPath}/${learningPath}`;
+        } else {
+          moduleId = `${learningPath}/${candidate}`;
+        }
       }
     }
 

--- a/frontend/scripts/generate-pages.ts
+++ b/frontend/scripts/generate-pages.ts
@@ -452,6 +452,9 @@ function generateModuleStructure(contentMap: ContentMap): void {
           let slug: string;
           if (section.slug === 'index' && topicSlug === learningPath) {
             slug = `/learn/${learningPath}`;
+          } else if (topicSlug === learningPath) {
+            // Direct files in learning path root (not in a subdirectory topic)
+            slug = `/learn/${learningPath}/${section.slug}`;
           } else {
             slug = `/learn/${learningPath}/${topicSlug}/${section.slug}`;
           }
@@ -483,7 +486,8 @@ function getLearningPathTitle(slug: string): string {
     'know_before_you_go': 'Know Before You Go',
     'cloud_security': 'Cloud Security',
     'cloud_security_development': 'Cloud Security Development',
-    'application_security': 'Application Security'
+    'application_security': 'Application Security',
+    'career_strategy': 'Career Strategy'
   };
   return titles[slug] || formatTitle(slug);
 }
@@ -564,7 +568,10 @@ function generatePages(contentMap: ContentMap): void {
     const nextTopic = topicIndex < allTopics.length - 1 ? allTopics[topicIndex + 1] : null;
     
     // Check if quiz.md exists in the topic directory and copy it to public
-    const topicDir = path.join(CONTENT_DIR, learningPath, topicSlug);
+    // For direct-file learning paths (where topicSlug === learningPath), quiz.md is in the learning path root
+    const topicDir = topicSlug === learningPath 
+      ? path.join(CONTENT_DIR, learningPath)
+      : path.join(CONTENT_DIR, learningPath, topicSlug);
     const quizSourcePath = path.join(topicDir, 'quiz.md');
     
     if (fs.existsSync(quizSourcePath)) {
@@ -607,6 +614,9 @@ function generatePages(contentMap: ContentMap): void {
       if (section.slug === 'index' && topicSlug === learningPath) {
         // This is an index.md in the learning path root, create at /learn/{learningPath}/
         pageDir = path.join(APP_LEARN_DIR, learningPath);
+      } else if (topicSlug === learningPath) {
+        // Direct files in learning path root (not in a subdirectory topic)
+        pageDir = path.join(APP_LEARN_DIR, learningPath, section.slug);
       } else {
         // Normal case: /learn/{learningPath}/{topic}/{section}/
         pageDir = path.join(APP_LEARN_DIR, learningPath, topicSlug, section.slug);
@@ -652,14 +662,20 @@ function generatePageComponent(
   topicMetadata?: TopicMetadata
 ): string {
   const previousUrl = previousSection 
-    ? `/learn/${learningPath}/${topicSlug}/${previousSection.slug}`
+    ? (topicSlug === learningPath 
+      ? `/learn/${learningPath}/${previousSection.slug}`
+      : `/learn/${learningPath}/${topicSlug}/${previousSection.slug}`)
     : null;
   
   let nextUrl: string | null = null;
   if (nextSection) {
-    nextUrl = `/learn/${learningPath}/${topicSlug}/${nextSection.slug}`;
+    nextUrl = topicSlug === learningPath
+      ? `/learn/${learningPath}/${nextSection.slug}`
+      : `/learn/${learningPath}/${topicSlug}/${nextSection.slug}`;
   } else if (nextTopicFirstSection && nextTopic) {
-    nextUrl = `/learn/${nextTopic.learningPath}/${nextTopic.topicSlug}/${nextTopicFirstSection.slug}`;
+    nextUrl = nextTopic.topicSlug === nextTopic.learningPath
+      ? `/learn/${nextTopic.learningPath}/${nextTopicFirstSection.slug}`
+      : `/learn/${nextTopic.learningPath}/${nextTopic.topicSlug}/${nextTopicFirstSection.slug}`;
   }
   
   // Only show quiz on the last section of a topic (but not for welcome page)

--- a/tasks.py
+++ b/tasks.py
@@ -25,6 +25,7 @@ from invoke import task
 from pathlib import Path
 from datetime import datetime
 import sys
+import platform
 import os
 import json
 import tempfile
@@ -47,8 +48,11 @@ def build_image(ctx, tag="latest"):
     print("=" * 60)
     print("Building Docker Image")
     print("=" * 60)
+
+    platform_flag = "--platform linux/amd64 " if platform.system() == "Darwin" else ""
+
     ctx.run(
-        f"docker build -t {ECR_REPO}:{tag} backend/",
+        f"docker build {platform_flag}-t {ECR_REPO}:{tag} backend/",
         pty=True,
     )
     print(f"\n✅ Docker image built: {ECR_REPO}:{tag}")

--- a/tasks.py
+++ b/tasks.py
@@ -191,10 +191,23 @@ def apply(c, total_module_pages=None, tag="latest"):
     print(f"   TOTAL_MODULE_PAGES set to: {total_module_pages}")
     print(f"   IMAGE_TAG set to: {tag}")
 
+<<<<<<< Updated upstream
     # Show deployment info
+=======
+    # Force a new deployment to ensure ECS pulls the latest image
+    print("\n🚀 Forcing new ECS deployment to pull latest image...")
+    ecs_cluster = "dsb-platform"
+    ecs_service = "dsb-platform"
+    c.run(
+        f"aws ecs update-service --cluster {ecs_cluster} --service {ecs_service} "
+        f"--force-new-deployment --region {AWS_REGION}",
+        hide=True,
+    )
+    print(f"   ✅ ECS service '{ecs_service}' force redeployed")
+
+>>>>>>> Stashed changes
     try:
         print("\n📊 Deployment Info:")
-        ecs_service = get_terraform_output(c, "ecs_service_name")
         alb_dns = get_terraform_output(c, "alb_dns_name")
         api_domain = get_terraform_output(c, "api_domain")
 
@@ -583,3 +596,52 @@ def deploy_all(c):
     print("\n" + "=" * 60)
     print("🎉 Full Deployment Complete!")
     print("=" * 60)
+<<<<<<< Updated upstream
+=======
+
+
+@task(pre=[fetch_content])
+def check_content_links(c):
+    """Extract links from Markdown content and check them with Linkinator.
+
+    This avoids crawling the rendered JS site (which Linkinator can't
+    navigate past auth walls) by pulling links directly from the
+    Markdown source before they're converted to JS components.
+    """
+    print("=" * 60)
+    print("Checking Content Links (Markdown source scan)")
+    print("=" * 60)
+
+    content_dir = Path("frontend/content")
+    link_pattern = re.compile(r"\[[^\]]*\]\(([^)]+)\)")
+
+    found_links = set()
+    md_files = list(content_dir.rglob("*.md")) + list(content_dir.rglob("*.mdx"))
+
+    print(f"\n Scanning {len(md_files)} Markdown files...")
+    for md_file in md_files:
+        text = md_file.read_text(encoding="utf-8", errors="ignore")
+        for match in link_pattern.findall(text):
+            if match.startswith("http"):
+                found_links.add(match)
+
+    print(f"   Found {len(found_links)} unique external links")
+
+    if not found_links:
+        print("\n  No links found to check.")
+        return
+
+    links_arg = " ".join(sorted(found_links))
+
+    print(f"\n🔗 Running Linkinator against {len(found_links)} links...")
+    result = c.run(
+        f"npx linkinator {links_arg} --format json > linkinator-content-results.json",
+        warn=True,
+    )
+
+    if result.exited != 0:
+        print("\n Linkinator found broken links!")
+        sys.exit(1)
+
+    print("\n All content links checked successfully!")
+>>>>>>> Stashed changes

--- a/tasks.py
+++ b/tasks.py
@@ -191,9 +191,6 @@ def apply(c, total_module_pages=None, tag="latest"):
     print(f"   TOTAL_MODULE_PAGES set to: {total_module_pages}")
     print(f"   IMAGE_TAG set to: {tag}")
 
-<<<<<<< Updated upstream
-    # Show deployment info
-=======
     # Force a new deployment to ensure ECS pulls the latest image
     print("\n🚀 Forcing new ECS deployment to pull latest image...")
     ecs_cluster = "dsb-platform"
@@ -205,7 +202,6 @@ def apply(c, total_module_pages=None, tag="latest"):
     )
     print(f"   ✅ ECS service '{ecs_service}' force redeployed")
 
->>>>>>> Stashed changes
     try:
         print("\n📊 Deployment Info:")
         alb_dns = get_terraform_output(c, "alb_dns_name")
@@ -596,8 +592,6 @@ def deploy_all(c):
     print("\n" + "=" * 60)
     print("🎉 Full Deployment Complete!")
     print("=" * 60)
-<<<<<<< Updated upstream
-=======
 
 
 @task(pre=[fetch_content])
@@ -644,4 +638,3 @@ def check_content_links(c):
         sys.exit(1)
 
     print("\n All content links checked successfully!")
->>>>>>> Stashed changes


### PR DESCRIPTION
Closes #154

## Summary

Introduces a full Career Strategy learning path (13 modules + quiz) to help learners navigate the non-technical side of building a cloud security/DevSecOps career. Also ships a broadcast notification system for admin-to-user communications and a new "Career Strategist" achievement badge.

## Career Strategy Content

New `frontend/content/career_strategy/` section covering:

| # | Module | Focus |
|---|--------|-------|
| 1 | Career Strategy Overview | High-level introduction to career navigation |
| 2 | The Psychology of the Job Search | Emotional resilience and managing uncertainty |
| 3 | Applying With Intention | Evaluating roles and avoiding blind applications |
| 4 | Understanding What Companies Are Really Evaluating | Signals beyond tools and keywords |
| 5 | Interview Mindset and Communication | Clear communication and showing judgment |
| 6 | Questions to Ask in Interviews | Revealing role scope, team maturity, culture |
| 7 | Questions to Avoid or Reframe | Timing, framing, and implicit signals |
| 8 | Certifications and Market Signals | Certs as credibility signals, not skill substitutes |
| 9 | Resume Positioning | Resume as signal document, not biography |
| 10 | Networking Basics | Building relationships without being transactional |
| 11 | Finding a Culture That Aligns With Your Values | Evaluating environment fit |
| 12 | Learning From Rejection | Debriefing outcomes without spiraling |
| 13 | Career Books and Reference Material | Curated resources and frameworks |

Plus a knowledge-check quiz (80% passing score).

## Frontend Changes

- Added "Career Strategy" as the 7th learning path in `lib/constants.ts`
- New curriculum stage in `lib/curriculum-data.ts` with topic breakdown
- Registered all 13 module pages in `lib/data/modules.json`
- Updated `CurriculumHero` description to reference career strategy
- Added `career_strategy` slug support in `scripts/generate-pages.ts`
- New `BroadcastModal` component — stacked modal for unread notifications (oldest-first)
- New `BroadcastManagement` admin component — compose with markdown preview, history, delete
- Dashboard integration: fetches and displays unread broadcasts on load

## Backend Changes

### Broadcast Notification System

- `broadcast_service.py` — DynamoDB CRUD with 90-day TTL, per-user dismissal tracking
- `broadcast_email.py` — SES delivery as a background task, renders markdown to HTML
- `broadcast_notification.html` — branded Jinja2 email template
- Admin endpoints: `POST /broadcasts`, `GET /broadcasts`, `DELETE /broadcasts/{id}`
- User endpoints: `GET /api/broadcasts/unread`, `POST /api/broadcasts/dismiss`
- New `broadcasts_table` config field in `app/config.py`

### Badge System

- Added `career_strategy` path completion tracking (12 page IDs) in `badge_service.py`
- New "Career Strategist" badge (compass) — awarded on full path completion

## Deployment / Tooling

- `tasks.py`: Added ECS force-redeploy step after `invoke apply` to ensure latest image is pulled
- `tasks.py`: New `invoke check-content-links` task — extracts external links from markdown source and validates with Linkinator (avoids auth-wall issues with JS site crawling)

## Testing

- [x] Career Strategy modules render correctly at `/learn/career_strategy/*`
- [x] Quiz passes/fails at 80% threshold
- [x] Career Strategy appears on curriculum page and learning paths grid
- [x] "Career Strategist" badge awarded after completing all 12 tracked pages
- [x] Admin can create/delete broadcasts
- [x] Users see unread broadcast modal on dashboard load
- [x] Broadcast email delivers with correct markdown rendering
- [x] `invoke check-content-links` runs successfully
