### PR TITLE
feat(blueprint): add Prowler local scan walkthrough

### DIFF
--- a/frontend/lib/walkthroughs-data.ts
+++ b/frontend/lib/walkthroughs-data.ts
@@ -11,6 +11,36 @@ import type { Walkthrough } from '@/lib/types';
 // This data is embedded at build time
 export const WALKTHROUGHS_DATA: Walkthrough[] = [
   {
+    "id": "prowler-local-scan",
+    "title": "Deploy Prowler Locally with Docker Compose and Scan Your AWS Account",
+    "description": "Deploy Prowler's self-hosted web UI with Docker Compose, connect it to your AWS account using read-only IAM credentials, and run a full account security scan — covering overall posture, compliance frameworks, and specific misconfigurations.",
+    "difficulty": "Beginner",
+    "topics": [
+      "AWS",
+      "Cloud Security",
+      "Prowler",
+      "Docker",
+      "CSPM",
+      "Security Assessment",
+      "IAM"
+    ],
+    "estimatedTime": 60,
+    "prerequisites": [
+      "Docker and Docker Compose installed",
+      "A personal AWS account you own or are authorized to scan",
+      "AWS Console access with permission to create IAM users",
+      "~4 GB of free RAM",
+      "Ports 3000 and 8080 available on your machine"
+    ],
+    "repository": "walkthroughs/prowler-local-scan",
+    "authors": [
+      {
+        "name": "Malik Dixon",
+        "url": "https://www.linkedin.com/in/mdixon47"
+      }
+    ]
+  },
+  {
     "id": "aws-detective-control",
     "title": "Event-Driven S3 Public Access Detective Control",
     "description": "Implement an automated security control to catch S3 bucket misconfigurations as they happen. This project leverages CloudTrail and EventBridge to trigger a Python-based Lambda function that evaluates live bucket settings and sends actionable alerts via SNS.",


### PR DESCRIPTION
## Summary

- Registers a new **Beginner**-level walkthrough in `walkthroughs-data.ts`: *Deploy Prowler Locally with Docker Compose and Scan Your AWS Account*
- Covers deploying Prowler's self-hosted web UI via Docker Compose, creating a least-privilege IAM user, running a full account scan, and reviewing findings across posture/compliance/misconfiguration dimensions
- Estimated time: 60 minutes; no prior Prowler experience required

## Content location

The walkthrough content (`README.md` + `metadata.json`) lives under `frontend/content/walkthroughs/prowler-local-scan/` and is populated at build time via the curriculum pipeline — it is gitignored per the project's convention.

## Metadata registered

| Field | Value |
|-------|-------|
| ID | `prowler-local-scan` |
| Difficulty | Beginner |
| Topics | AWS, Cloud Security, Prowler, Docker, CSPM, Security Assessment, IAM |
| Est. time | 60 min |

## Test plan

- [ ] Verify `prowler-local-scan` appears in the walkthroughs listing page after build
- [ ] Confirm metadata passes the `validateMetadata` checks in `walkthroughs.ts`
- [ ] Confirm PR title passes the `pr-title.yml` lint check

🤖 Generated with [Claude Code](https://claude.com/claude-code)