### PR TITLE
feat(skill): add DSB DevSecOps Engineering Claude Skill (v0.1.0)

### DIFF
--- a/devsecops-engineering-skill/.claude-plugin/plugin.json
+++ b/devsecops-engineering-skill/.claude-plugin/plugin.json
@@ -1,0 +1,22 @@
+{
+  "name": "devsecops-engineer",
+  "version": "0.1.0",
+  "description": "Teach, advise on, design, generate, and review DevSecOps delivery pipelines using The DevSec Blueprint engineering methodology — capability-based, vendor-neutral, and workload-driven.",
+  "author": {
+    "name": "The DevSec Blueprint",
+    "url": "https://github.com/devsecblueprint"
+  },
+  "homepage": "https://github.com/devsecblueprint/devsecops-claude-skill",
+  "repository": "https://github.com/devsecblueprint/devsecops-claude-skill",
+  "license": "MIT",
+  "keywords": [
+    "devsecops",
+    "ci-cd",
+    "pipeline-security",
+    "supply-chain-security",
+    "sast",
+    "sca",
+    "iac-security",
+    "devsecblueprint"
+  ]
+}

--- a/devsecops-engineering-skill/.github/workflows/validate.yml
+++ b/devsecops-engineering-skill/.github/workflows/validate.yml
@@ -1,0 +1,70 @@
+# This repository practices the methodology it teaches.
+#
+# DSB-SCAN-001  a Scan phase exists
+# DSB-SCAN-004  secret scanning, always applicable
+# DSB-SCAN-008  the pipeline definition is itself in scope
+# DSB-SC-002    third-party actions pinned to immutable commit SHAs
+# DSB-ID-002    least-privilege permissions, opted into per job
+# DSB-EVD-001   machine-readable evidence, retained
+name: Validate
+
+on:
+  push:
+    branches: [main]
+  pull_request:
+    branches: [main]
+
+# DSB-ID-002 — least privilege by default.
+permissions:
+  contents: read
+
+concurrency:
+  group: validate-${{ github.ref }}
+  cancel-in-progress: true
+
+jobs:
+  rules:
+    # DSB-TEST-001 — the catalog's own validation is this project's test suite.
+    name: Rule catalog
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@11bd71901bbe5b1630ceea73d27597364c9af683 # v4.2.2
+
+      - uses: astral-sh/setup-uv@b5f58b2abc5763ade55e4e9d0fe52cd1ff7979ca # v5.2.1
+        with:
+          enable-cache: true
+
+      - name: Validate rule catalog
+        run: uv run --with pyyaml python scripts/validate_rules.py
+
+  secret-scan:
+    # DSB-SCAN-004 — always applicable, no technology condition. Full history:
+    # a secret removed in a later commit is still a live credential.
+    name: Secret scan
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@11bd71901bbe5b1630ceea73d27597364c9af683 # v4.2.2
+        with:
+          fetch-depth: 0
+
+      - uses: gitleaks/gitleaks-action@83373cf2f8c4db6e24b41c1a9b086bb9619e9cd3 # v2.3.7
+        env:
+          GITLEAKS_ENABLE_SUMMARY: "true"
+
+  workflow-scan:
+    # DSB-SCAN-008 — pipeline definitions live in this repository, so they are
+    # in scope for scanning like any other code.
+    name: Workflow config scan
+    runs-on: ubuntu-latest
+    permissions:
+      contents: read
+      security-events: write # DSB-EVD-001 — SARIF upload
+    steps:
+      - uses: actions/checkout@11bd71901bbe5b1630ceea73d27597364c9af683 # v4.2.2
+
+      - uses: zizmorcore/zizmor-action@5ca5fc7a4779c5263a3ffa0e1f693009994446d1 # v0.1.2
+        with:
+          # Enforcement: WARN, the DSB-SCAN-008 default. Findings are surfaced
+          # in the Security tab without blocking the pull request.
+          advanced-security: false
+          persona: regular

--- a/devsecops-engineering-skill/.gitignore
+++ b/devsecops-engineering-skill/.gitignore
@@ -1,0 +1,18 @@
+# Python
+__pycache__/
+*.py[cod]
+.venv/
+venv/
+
+# Packaged skill bundles
+*.skill
+
+# Tooling output
+*.sarif
+.ruff_cache/
+.pytest_cache/
+
+# Editor / OS
+.DS_Store
+.idea/
+*.swp

--- a/devsecops-engineering-skill/CHANGELOG.md
+++ b/devsecops-engineering-skill/CHANGELOG.md
@@ -1,0 +1,93 @@
+# Changelog
+
+All notable changes to this project are documented here.
+
+The format follows [Keep a Changelog](https://keepachangelog.com/en/1.1.0/), and this
+project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html) — with the
+Pre-1.0 caveat stated under v0.1.0 below.
+
+---
+
+## [Unreleased]
+
+### Planned
+
+- Direct links from individual rules to the DSB curriculum modules they correspond to
+- Additional examples across further platforms and stacks (Azure DevOps, serverless)
+- Evaluation prompts exercising each operating mode
+
+---
+
+## [0.1.0] — 2026-08-16
+
+Initial release.
+
+### Added
+
+- **Skill definition** (`SKILL.md`) — the Build → Test → Scan → Deploy methodology, three
+  operating modes (Advise, Design/Generate, Review), the 20 Baseline DSB Engineering
+  Principles, the workload context checklist, the control selection algorithm, and the
+  output contract
+- **Rule catalog** — 42 rules across 11 families, each carrying the full schema:
+  `id`, `title`, `phase`, `requirement`, `rationale`, `applicability`,
+  `framework_mappings`, `enforcement.level`, `enforcement.automatable`,
+  `tooling.examples`, `tooling.prefer_existing_tool`
+
+  | Family | Rules | Scope |
+  |---|---:|---|
+  | `DSB-BUILD-*` | 4 | Build and artifact creation |
+  | `DSB-TEST-*` | 3 | Testing |
+  | `DSB-SCAN-*` | 10 | Security scanning and validation |
+  | `DSB-DEPLOY-*` | 4 | Deployment and promotion |
+  | `DSB-ID-*` | 3 | Workload identity, authentication, authorization |
+  | `DSB-SRC-*` | 3 | Source control and repository security |
+  | `DSB-SC-*` | 3 | Software supply chain security |
+  | `DSB-ART-*` | 4 | Artifacts, provenance, signing, registries |
+  | `DSB-IAC-*` | 3 | Infrastructure-as-code security |
+  | `DSB-EVD-*` | 3 | Evidence, logging, observability |
+  | `DSB-EXC-*` | 2 | Exceptions and risk acceptance |
+
+- **Command entry points** — `/devsecops-engineer:advise`, `:design`, `:assess`, plus
+  `.claude-plugin/plugin.json`. Commands are thin wrappers over the skill; a
+  commands-stay-thin policy is documented in `CONTRIBUTING.md` to prevent drift
+- **Reference documentation** — `applicability.md` (five-step selection flow),
+  `capability-catalog.md` (capability → condition → placement → owning rule),
+  `enforcement-model.md` (BLOCK / WARN / REPORT / N/A and the exception path),
+  `framework-mappings.md` (NIST SSDF, SLSA, OWASP CI/CD, OWASP SAMM, CNCF)
+- **Worked examples** — Advise (Jenkins/Java/OpenShift enterprise), Generate (GitHub
+  Actions/Node/container to EKS; GitLab CI/Terraform), Review (Jenkinsfile assessment
+  with compliant, non-compliant, and Not Applicable findings)
+- **Validation** — `scripts/validate_rules.py` checking required schema fields, family
+  ID prefixes, ID uniqueness, allowed phases, enforcement levels, framework mapping keys,
+  tooling flags, and per-family rule counts
+- **CI** — `.github/workflows/validate.yml` running catalog validation, secret scanning
+  (`DSB-SCAN-004`), and workflow configuration scanning (`DSB-SCAN-008`) on every push
+  and pull request
+- **Project documentation** — README as a product-oriented front door, `CONTRIBUTING.md`,
+  `MAINTAINERS.md`, `SECURITY.md`, MIT `LICENSE`, and `docs/legal/TRADEMARKS.md`
+
+### Pre-1.0 notice
+
+This is an **initial release and the catalog's shape is not final.** Before 1.0, expect:
+
+- New rules and new families as the taxonomy is refined
+- Changes to enforcement defaults and applicability conditions
+- Restructuring of reference documentation
+
+**Rule IDs are stable from this release onward.** A withdrawn rule is deprecated, never
+renumbered, and its ID is never reused — so a pipeline annotated with `DSB-SCAN-003`
+means the same thing in every future version. This is the compatibility guarantee that
+matters, because rule IDs travel into other organizations' pipelines, review findings,
+and exception records.
+
+Compliance framework mapping (SOC 2, PCI DSS, FedRAMP, HIPAA) is deferred by design.
+Compliance is not this methodology's driver.
+
+### Licensing
+
+Released under the **MIT License**. No commercial authorization is required to use,
+modify, or distribute this implementation. DSB branding, trademarks, and curriculum
+remain outside the MIT grant — see `docs/legal/TRADEMARKS.md`.
+
+[Unreleased]: https://github.com/devsecblueprint/devsecops-claude-skill/compare/v0.1.0...HEAD
+[0.1.0]: https://github.com/devsecblueprint/devsecops-claude-skill/releases/tag/v0.1.0

--- a/devsecops-engineering-skill/CONTRIBUTING.md
+++ b/devsecops-engineering-skill/CONTRIBUTING.md
@@ -1,0 +1,157 @@
+# Contributing
+
+Thanks for wanting to improve this. Read the two policies below before opening a PR —
+they are the ones that get contributions sent back.
+
+---
+
+## Policy 1 — Curriculum first
+
+**The DSB curriculum is the source of truth. This skill is an implementation of it.**
+
+A change to engineering guidance belongs in the curriculum before it lands here. If you
+believe a rule is wrong, the discussion is about the methodology, not about the YAML.
+
+| Change | Where it starts |
+|---|---|
+| New engineering guidance, or a change to existing guidance | Curriculum, then here |
+| A rule's requirement text is unclear or ambiguous | Here — that is an implementation defect |
+| Framework mapping is wrong or missing | Here |
+| An example is wrong, outdated, or misleading | Here |
+| A tool named in `tooling.examples` no longer exists | Here |
+
+Open an issue before a large rule change. A PR adding six new rules will be asked what
+curriculum change it implements.
+
+---
+
+## Policy 2 — Commands stay thin
+
+`commands/*.md` load the skill and set the operating mode. **No rule logic lives there.**
+
+Every command is a thin wrapper over `SKILL.md` and `rules/*.yaml`. This exists to
+prevent drift: if a command file starts explaining applicability, or listing which
+scanners a Node project needs, there are now two sources of truth and they will disagree
+within a release.
+
+If a command needs behavior the skill does not provide, add it to the skill.
+
+---
+
+## Rule IDs are permanent
+
+**Deprecate, never renumber. Never reuse.**
+
+Rule IDs appear in generated pipeline comments, review findings, and exception records
+across every organization using this skill. An ID that changes meaning silently
+invalidates all of it.
+
+To withdraw a rule:
+
+1. Leave the rule in place
+2. Add `deprecated: true` and `deprecated_reason` and `superseded_by` where applicable
+3. Note it in `CHANGELOG.md`
+4. Never assign that ID again
+
+To add a rule: take the next number in the family. Gaps are fine — they are evidence of
+history, not defects.
+
+---
+
+## Adding or changing a rule
+
+Every rule carries the full schema. `scripts/validate_rules.py` enforces it.
+
+```yaml
+- id: DSB-<FAMILY>-<NNN>       # family prefix must match the file's `family`
+  title: <short imperative statement>
+  phase: build | test | scan | deploy | cross-cutting
+  requirement: >-              # what must be true. Testable. No vendor names.
+  rationale: >-                # WHY. What fails without it. This is the teaching.
+  applicability:
+    always: <bool>
+    conditions: []             # required if always: false
+    not_applicable_when: []
+  framework_mappings:          # all five keys required; empty list is valid
+    nist_ssdf: []
+    slsa: []
+    owasp_cicd: []
+    owasp_samm: []
+    cncf_supply_chain: []
+  enforcement:
+    level: block | warn | report   # DSB default, not a mandate
+    automatable: <bool>
+  tooling:
+    examples: []               # ILLUSTRATIVE ONLY
+    prefer_existing_tool: true # always true — this is not optional
+```
+
+### What makes a good rule
+
+- **Capability, not product.** "Software composition analysis", never "run Snyk".
+- **Testable.** Someone must be able to look at a pipeline and say yes or no.
+- **Honest applicability.** If it does not apply to some workloads, say which — a rule
+  marked `always: true` that is not always true teaches engineers to ignore N/A.
+- **A rationale that teaches.** Explain what actually goes wrong. "It is a best practice"
+  is not a rationale and fails Principle 20.
+- **Correct enforcement default.** Do not default everything to BLOCK. A high-noise BLOCK
+  gate is how pipelines acquire `continue-on-error`.
+
+### What gets rejected
+
+- Requiring a specific vendor or product
+- A rule that duplicates an existing rule's capability
+- Enforcement defaults with no stated reasoning
+- Rules that only make sense for one organization's setup
+- `prefer_existing_tool: false`
+
+---
+
+## Testing
+
+```bash
+uv run --with pyyaml python scripts/validate_rules.py
+```
+
+The validator checks required fields, family prefixes, ID uniqueness, allowed phases and
+enforcement levels, framework mapping keys, tooling flags, and per-family rule counts.
+
+**Changing a rule count means updating `EXPECTED_FAMILIES` in the validator.** That is
+deliberate friction — adding or removing a rule should be a conscious act with a
+`CHANGELOG.md` entry, not a side effect.
+
+CI runs the same validation plus secret scanning (`DSB-SCAN-004`) and workflow config
+scanning (`DSB-SCAN-008`). This repository practices the methodology it teaches; a
+contribution that would fail its own catalog will not merge.
+
+---
+
+## Contributing an example
+
+Examples carry disproportionate weight — they are what people copy. An example must:
+
+- Follow the output contract in `SKILL.md` §7 completely
+- Include a **Not Applicable** section with real determinations and real reasons
+- Annotate generated code with rule IDs in comments
+- Pin third-party components by immutable reference (`DSB-SC-002`) — and if you cannot
+  verify a digest, say so in the example rather than leaving an unverified pin looking
+  authoritative
+- Show a workload that genuinely excludes some controls. An example where everything
+  applies teaches nothing about selection.
+
+---
+
+## Pull requests
+
+1. Branch from `main`
+2. Run the validator
+3. Update `CHANGELOG.md` under Unreleased
+4. Describe **what engineering problem** the change solves, not just what it changes
+5. For rule changes, link the curriculum material it implements
+
+---
+
+## Code of conduct
+
+Be decent. Assume good faith. Argue about engineering, not about people. Maintainers may
+remove contributions or contributors that make this a worse place to work.

--- a/devsecops-engineering-skill/LICENSE
+++ b/devsecops-engineering-skill/LICENSE
@@ -1,0 +1,21 @@
+MIT License
+
+Copyright (c) 2026 The DevSec Blueprint
+
+Permission is hereby granted, free of charge, to any person obtaining a copy
+of this software and associated documentation files (the "Software"), to deal
+in the Software without restriction, including without limitation the rights
+to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+copies of the Software, and to permit persons to whom the Software is
+furnished to do so, subject to the following conditions:
+
+The above copyright notice and this permission notice shall be included in all
+copies or substantial portions of the Software.
+
+THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+SOFTWARE.

--- a/devsecops-engineering-skill/MAINTAINERS.md
+++ b/devsecops-engineering-skill/MAINTAINERS.md
@@ -1,0 +1,77 @@
+# Maintainers
+
+This project is owned and maintained by **The DevSec Blueprint**.
+
+---
+
+## Ownership
+
+| | |
+|---|---|
+| **Owner** | The DevSec Blueprint |
+| **Organization** | [github.com/devsecblueprint](https://github.com/devsecblueprint) |
+| **License** | [MIT](LICENSE) |
+| **Trademarks and curriculum** | Not covered by the MIT grant — see [`docs/legal/TRADEMARKS.md`](docs/legal/TRADEMARKS.md) |
+
+The MIT license applies to this implementation — the rule catalog, skill definition,
+references, examples, and scripts. **No commercial authorization is required to use,
+modify, or distribute it.**
+
+---
+
+## Responsibilities
+
+Maintainers:
+
+- Review and merge contributions per [`CONTRIBUTING.md`](CONTRIBUTING.md)
+- Guard the two standing policies: curriculum-first, and commands-stay-thin
+- Enforce rule ID stability — deprecate, never renumber, never reuse
+- Keep the catalog aligned with DSB curriculum as it evolves
+- Cut releases and maintain [`CHANGELOG.md`](CHANGELOG.md)
+
+Maintainers do **not** decide DSB engineering methodology in this repository. That lives
+in the curriculum; this repository implements it.
+
+---
+
+## Decision-making
+
+| Change | Requires |
+|---|---|
+| Typos, formatting, broken links | One maintainer approval |
+| New or corrected examples | One maintainer approval |
+| Framework mapping corrections | One maintainer approval |
+| New rule, or changed requirement text | Maintainer approval + linked curriculum material |
+| Rule deprecation | Maintainer approval + `CHANGELOG.md` entry |
+| New rule family | Maintainer consensus — taxonomy changes affect every consumer |
+| License or trademark terms | DSB ownership decision, not a maintainer decision |
+
+---
+
+## Releases
+
+Semantic versioning, with a Pre-1.0 caveat:
+
+- **Pre-1.0** — the catalog's shape is still settling. Minor versions may add families,
+  change enforcement defaults, and refine applicability conditions.
+- **Rule IDs are stable regardless of version.** This is the compatibility guarantee that
+  matters, because rule IDs travel into other organizations' pipelines and exception
+  records.
+
+Release steps:
+
+1. Validation passes: `uv run --with pyyaml python scripts/validate_rules.py`
+2. `CHANGELOG.md` updated with the version and date
+3. Version bumped in `.claude-plugin/plugin.json`
+4. Tag `vX.Y.Z` and publish the release
+
+---
+
+## Contact
+
+- **Issues and proposals** — open an issue in this repository
+- **Security concerns** — see [`SECURITY.md`](SECURITY.md)
+- **Community** — the DSB Discord, linked from the
+  [main DSB repository](https://github.com/devsecblueprint/devsecblueprint)
+- **Trademark, branding, or curriculum licensing** — reach The DevSec Blueprint directly;
+  these are outside the MIT grant

--- a/devsecops-engineering-skill/README.md
+++ b/devsecops-engineering-skill/README.md
@@ -1,0 +1,200 @@
+# DSB DevSecOps Engineering Skill
+
+**A Claude Skill that designs, reviews, and explains DevSecOps delivery pipelines using
+the engineering methodology taught throughout [The DevSec Blueprint](https://github.com/devsecblueprint).**
+
+[![License: MIT](https://img.shields.io/badge/License-MIT-yellow.svg?style=for-the-badge)](LICENSE)
+![Status](https://img.shields.io/badge/status-v0.1.0%20Pre--1.0-orange?style=for-the-badge)
+![Rules](https://img.shields.io/badge/rules-42%20across%2011%20families-blue?style=for-the-badge)
+
+---
+
+## What is this?
+
+A packaged set of instructions that teaches Claude how a DevSecOps engineer actually
+reasons about a delivery pipeline: which security controls a workload genuinely needs,
+where each one belongs, what should block a release, and what should not be there at all.
+
+It encodes **42 rules across 11 families** and a control-selection algorithm. It is
+**capability-based, never vendor-based** — DSB defines the required capabilities and
+engineering outcomes; your organization decides how to implement them.
+
+**This is not a generic pipeline generator.** It will not hand you a template with every
+scanner switched on. It works out what your workload is, and tells you what that workload
+actually requires — including what it does not.
+
+> Build what you need. Test what you built. Scan what can introduce meaningful risk.
+> Deploy only what passed.
+
+---
+
+## Why use it
+
+| Outcome | What that means in practice |
+|---|---|
+| **No tooling bloat** | No container scanner without a container. No IaC scanner without IaC. No second SCA tool when you already own one. |
+| **Your existing tools count** | Own Checkmarx, Black Duck, Prisma? Those satisfy the rules. Built something internal? That satisfies them identically. |
+| **Explicit Not Applicable** | Every excluded control is named with its reason. Silence is never an answer. |
+| **Right control, right place** | Controls run at the earliest stage where they produce *meaningful* results — not the earliest stage possible. |
+| **Enforcement you chose** | BLOCK / WARN / REPORT recommended per control, with the trade-off stated so you can overrule it deliberately. |
+| **Decisions, not just YAML** | Every recommendation carries a rule ID and a rationale you can defend in a design review. |
+
+---
+
+## Install in 60 seconds
+
+**As a Claude Code plugin** — adds the `/devsecops-engineer:*` commands:
+
+```bash
+git clone https://github.com/devsecblueprint/devsecops-claude-skill.git
+claude plugin install ./devsecops-claude-skill
+```
+
+**As a personal skill** — available in every session, no commands:
+
+```bash
+git clone https://github.com/devsecblueprint/devsecops-claude-skill.git \
+  ~/.claude/skills/devsecops-engineering
+```
+
+**For one project** — commit it so the whole team gets it:
+
+```bash
+git clone https://github.com/devsecblueprint/devsecops-claude-skill.git \
+  .claude/skills/devsecops-engineering
+```
+
+---
+
+## Try it
+
+**Advise** — you have tools and an architecture, and want to know what you are missing:
+
+```
+/devsecops-engineer:advise We run Jenkins, Java/Maven, artifacts in Artifactory,
+deploy to OpenShift. We own Checkmarx, Black Duck, and Prisma Cloud.
+```
+
+**Design** — you want a pipeline built for your actual stack:
+
+```
+/devsecops-engineer:design Node.js API, TypeScript, container image to ECR,
+deployed to EKS via GitHub Actions. Greenfield, no security tooling yet.
+```
+
+**Assess** — you have a pipeline and want it reviewed:
+
+```
+/devsecops-engineer:assess .github/workflows/deploy.yml
+```
+
+Without the plugin installed, describe the task in plain language — the skill activates
+on its own.
+
+---
+
+## Common workflows
+
+| Situation | Start with | You get |
+|---|---|---|
+| Inherited a pipeline nobody understands | `assess` | Findings by category, remediation ranked by risk |
+| New service, no pipeline yet | `design` | Implementation-ready config, annotated with rule IDs |
+| "Do we need to buy another scanner?" | `advise` | Usually no — a mapping of what you own to what you need |
+| Audit asked which frameworks you cover | `advise` | NIST SSDF / SLSA / OWASP CI/CD / SAMM / CNCF mappings |
+| Pipeline is slow and teams route around it | `assess` | Duplicate tooling and mis-levelled gates identified |
+| Onboarding an engineer to DevSecOps | any mode | Every answer teaches the decision, not just the config |
+
+---
+
+## How it works
+
+```
+1. WORKLOAD PROFILING     What does this actually build, produce, and deploy?
+          ↓
+2. APPLICABILITY          Does the triggering technology or risk exist?
+          ↓               NO → Not Applicable, reason recorded. Stop.
+3. CAPABILITY RESOLUTION  Does an existing tool already cover this?
+          ↓               YES → Satisfied. Do not add a second.
+4. OWNERSHIP BOUNDARY     Does another governed process own it?
+          ↓               YES → Satisfied (externally owned), process named.
+5. ENFORCEMENT            BLOCK, WARN, or REPORT — and what you trade either way.
+          ↓
+6. PLACEMENT              Earliest technically valid stage producing meaningful results.
+```
+
+Every delivery pipeline maps to four logical phases — **Build → Test → Scan → Deploy**.
+They describe engineering intent, not job names. Runtime-dependent controls (DAST, API
+security testing) run after deployment but belong to Scan/verification, not a fifth
+phase.
+
+---
+
+## Go deeper
+
+| | |
+|---|---|
+| [`SKILL.md`](SKILL.md) | The methodology, operating modes, 20 baseline principles, and output contract |
+| [`rules/`](rules/) | The 42-rule catalog — the authoritative requirement text |
+| [`references/applicability.md`](references/applicability.md) | The control selection flow in full |
+| [`references/capability-catalog.md`](references/capability-catalog.md) | Capability → condition → placement → owning rule |
+| [`references/enforcement-model.md`](references/enforcement-model.md) | BLOCK / WARN / REPORT / N/A and the exception path |
+| [`references/framework-mappings.md`](references/framework-mappings.md) | NIST SSDF, SLSA, OWASP CI/CD, OWASP SAMM, CNCF |
+| [`examples/`](examples/) | Four worked outputs — Advise, two Generate, and a Review |
+| [`CONTRIBUTING.md`](CONTRIBUTING.md) | Rule change policy, testing, and the curriculum-first requirement |
+
+**Validate the catalog:**
+
+```bash
+uv run --with pyyaml python scripts/validate_rules.py
+# OK — 42 rules across 11 families
+```
+
+---
+
+## Status — v0.1.0 (Pre-1.0)
+
+This is an **initial release**. The methodology is settled; the catalog's shape is not
+finished.
+
+Expect during Pre-1.0:
+
+- New rules and new families as the taxonomy is refined
+- Changes to enforcement defaults and applicability conditions
+- Additional examples across more platforms and stacks
+- Direct links from rules to the DSB curriculum modules they correspond to
+
+**Rule IDs are stable once merged.** A rule that is withdrawn is deprecated, never
+renumbered, and its ID is never reused — so any pipeline annotated with a DSB rule ID
+stays meaningful.
+
+Compliance framework mapping (SOC 2, PCI DSS, FedRAMP, HIPAA) is **deferred by design**.
+Compliance is not this methodology's driver.
+
+---
+
+## Contributing
+
+Contributions are welcome — read [`CONTRIBUTING.md`](CONTRIBUTING.md) first. Two rules
+matter most:
+
+1. **Curriculum first.** The DSB curriculum is the source of truth; this skill is an
+   implementation of it. A change in engineering guidance belongs in the curriculum
+   before it lands here.
+2. **Commands stay thin.** No rule logic in `commands/` — they load the skill and set the
+   mode, nothing more.
+
+---
+
+## License and ownership
+
+Licensed under the [MIT License](LICENSE).
+
+The **DevSec Blueprint** name, branding, and curriculum are owned by The DevSec Blueprint
+and are **not** covered by the MIT grant — see [`docs/legal/TRADEMARKS.md`](docs/legal/TRADEMARKS.md).
+The MIT license covers this implementation: the rule catalog, skill definition,
+references, examples, and scripts.
+
+---
+
+*Owned and maintained by The DevSec Blueprint. This skill is an implementation of DSB
+knowledge and standards, not the source of those standards.*

--- a/devsecops-engineering-skill/SECURITY.md
+++ b/devsecops-engineering-skill/SECURITY.md
@@ -1,0 +1,79 @@
+# Security Policy
+
+## Reporting a vulnerability
+
+Report security issues **privately**. Do not open a public issue.
+
+- Use [GitHub private vulnerability reporting](https://docs.github.com/code-security/security-advisories/guidance-on-reporting-and-writing/privately-reporting-a-security-vulnerability)
+  on this repository, or
+- Contact The DevSec Blueprint maintainers through the channels in
+  [`MAINTAINERS.md`](MAINTAINERS.md)
+
+Please include what you found, how to reproduce it, and what you think the impact is.
+
+---
+
+## Scope
+
+This repository contains documentation, YAML rule definitions, and a validation script.
+It ships no runtime service. The security-relevant surface is smaller than a typical
+project's, and specific:
+
+**In scope:**
+
+| Concern | Why it matters |
+|---|---|
+| **Incorrect security guidance** | A rule or example that leads someone to build an insecure pipeline is the highest-impact defect this project can have — report it as a security issue, not a bug |
+| **Insecure example configuration** | Generated pipeline examples that would leak credentials, over-privilege a job, or expose an environment |
+| **Unpinned or malicious third-party actions** | In this repository's own workflows (`DSB-SC-002`) |
+| **Supply chain issues** | In `scripts/` dependencies |
+| **Credentials committed to this repository** | `DSB-SCAN-004` — CI scans for this, but report anything CI missed |
+
+**Out of scope:**
+
+- Disagreement with a rule's enforcement default — open a normal issue
+- Requests for new rules — open a normal issue
+- Vulnerabilities in tools merely *named* in `tooling.examples` — those lists are
+  illustrative and confer no endorsement; report to the tool's own maintainers
+
+---
+
+## Guidance defects are security defects
+
+This is the unusual part of this project's threat model, and it is worth stating plainly.
+
+The output of this skill becomes other organizations' delivery pipelines. A rule with a
+wrong applicability condition can cause a control to be skipped across every consumer at
+once — quietly, and with a written justification that makes it look deliberate. That is a
+larger blast radius than most code vulnerabilities.
+
+So: if you find guidance here that would cause someone to omit a control they need, place
+one where it cannot work, or accept risk they did not understand they were accepting,
+report it through this policy.
+
+---
+
+## Supported versions
+
+During Pre-1.0, only the latest release is supported. Fixes land on `main` and ship in
+the next release.
+
+| Version | Supported |
+|---|---|
+| 0.1.x | ✅ |
+| < 0.1 | ❌ (no such releases) |
+
+---
+
+## This repository's own controls
+
+Enforced in [`.github/workflows/validate.yml`](.github/workflows/validate.yml):
+
+- Rule catalog validation (`DSB-TEST-001`)
+- Secret scanning, full history (`DSB-SCAN-004`)
+- Workflow configuration scanning (`DSB-SCAN-008`)
+- All third-party actions pinned to commit SHAs (`DSB-SC-002`)
+- Least-privilege workflow permissions (`DSB-ID-002`)
+
+If you can find a way past any of these, that is exactly the kind of report this policy
+is for.

--- a/devsecops-engineering-skill/SKILL.md
+++ b/devsecops-engineering-skill/SKILL.md
@@ -1,0 +1,267 @@
+---
+name: devsecops-engineering
+description: Teach, advise on, design, generate, and review DevSecOps delivery pipelines using The DevSec Blueprint engineering methodology. Use when the user asks to design or generate a CI/CD pipeline, review an existing pipeline or Jenkinsfile/workflow/GitLab CI config, assess a delivery process for security gaps, decide which security scanners a workload actually needs, place security controls in a pipeline, or reconcile existing organizational security tooling against a required capability set. Applies to any CI/CD platform (GitHub Actions, Jenkins, GitLab CI, Azure DevOps, others), any cloud, and any security product stack.
+license: MIT
+---
+
+# DSB DevSecOps Engineering
+
+You are applying **The DevSec Blueprint (DSB) DevSecOps engineering methodology**.
+
+DSB defines the **required capabilities and engineering outcomes**. The organization
+determines **how those capabilities are implemented**. You never prescribe a vendor
+stack, and you never generate a pipeline that carries tooling the workload does not need.
+
+> Build what you need. Test what you built. Scan what can introduce meaningful risk.
+> Deploy only what passed.
+
+**Repository access is not required.** All three operating modes work entirely from
+context the user supplies — an architecture description, a pasted pipeline file, a list
+of tools the organization already owns.
+
+---
+
+## 1. The four phases
+
+Every delivery pipeline follows four logical phases. They describe **engineering
+intent**, not job names, stage names, vendors, or platforms. A pipeline with one job or
+thirty jobs still maps onto these four.
+
+```
+BUILD → TEST → SCAN → DEPLOY
+```
+
+| Phase | Intent |
+|---|---|
+| **Build** | Repeatable, traceable preparation of a deliverable — compilation, dependency resolution, packaging, image construction, IaC preparation, artifact generation. |
+| **Test** | Workload-appropriate validation that the deliverable *behaves* correctly. Conceptually separate from scanning. |
+| **Scan** | Validation that the deliverable does not introduce meaningful, detectable security risk. Non-negotiable as a phase; individual scanners are conditional on the workload. |
+| **Deploy** | Delivery, publication, or promotion of **only** artifacts that passed every applicable Build, Test, and Scan requirement. |
+
+**Runtime-dependent controls are not a fifth phase.** DAST, API security testing, and
+runtime validation execute *after* deployment to an appropriate testable environment,
+but they belong to Scan/verification (`DSB-SCAN-009`, `DSB-DEPLOY-004`).
+
+**Active DAST against production without explicit organizational authorization is
+prohibited.** Never generate it, never recommend it without naming the authorization
+requirement.
+
+---
+
+## 2. Operating modes
+
+Determine which mode the user is in from what they gave you. When it is genuinely
+ambiguous, ask one question and proceed.
+
+### Mode 1 — Advise
+
+*Trigger:* the user describes an organization, architecture, toolset, or requirement set
+and wants guidance.
+
+1. Map the tools and processes they already have onto Build → Test → Scan → Deploy.
+2. Identify gaps — required capabilities with no owning tool or process.
+3. Identify controls that are **Satisfied (externally owned)** by another governed
+   process, and name that process.
+4. Recommend enforcement points and levels.
+5. Explain every decision with a DSB rule ID.
+
+Do **not** produce pipeline code in this mode unless asked.
+
+### Mode 2 — Design / Generate
+
+*Trigger:* the user wants a pipeline built.
+
+1. Establish workload context (§4). Ask for what is missing **or** state explicit
+   assumptions — never silently guess.
+2. Resolve applicable rules (§5).
+3. Produce implementation-ready configuration for their actual platform.
+4. Annotate the generated code with rule references in comments.
+5. Follow the output contract (§7), including the Not Applicable section.
+
+### Mode 3 — Review
+
+*Trigger:* the user pastes or points at an existing pipeline, repository, or config.
+
+Use this fixed findings structure, in this order:
+
+1. **Satisfied controls** — what the pipeline already does correctly, with rule IDs.
+2. **Missing capabilities** — required and applicable, absent.
+3. **Inappropriate enforcement** — present but at the wrong level or wrong stage.
+4. **Duplicate tooling** — two tools covering one capability (`DSB-SCAN-010`).
+5. **Pipeline security weaknesses** — the pipeline as an attack surface: static
+   credentials, unpinned third-party components, over-privileged jobs, secret leakage.
+6. **Not Applicable** — controls deliberately absent, with justification.
+7. **Remediation** — ordered by risk, each tied to a rule ID.
+
+---
+
+## 3. The 20 Baseline DSB Engineering Principles
+
+1. Every delivery pipeline maps to Build → Test → Scan → Deploy.
+2. Security scanning is considered in every delivery design, without exception.
+3. A scanner is required only when the technology, artifact, or risk it addresses
+   actually exists in the workload.
+4. Capabilities are required; products are not.
+5. An existing organizational tool that satisfies a capability satisfies the DSB rule.
+6. The minimum sufficient toolchain wins. Duplicate coverage is a defect, not depth.
+7. Not Applicable is a first-class outcome and must be stated explicitly, never implied
+   by omission.
+8. Controls execute at the earliest technically valid stage where they produce
+   meaningful results.
+9. Testing validates behavior; scanning validates risk. Neither substitutes for the
+   other.
+10. No meaningless tests written solely to satisfy the Test phase.
+11. Only artifacts that passed every applicable gate may be deployed or promoted.
+12. The artifact that was tested and scanned is the artifact that ships — never a
+    rebuild.
+13. Control **applicability** is an engineering decision driven by the workload; control
+    **enforcement** is a policy decision owned by the organization.
+14. A control owned and enforced by another governed organizational process need not be
+    duplicated in the application pipeline.
+15. Pipelines authenticate with short-lived, scoped workload identity — not long-lived
+    static credentials.
+16. The pipeline is production infrastructure and is itself in scope for security.
+17. Every gate produces retained, machine-readable evidence.
+18. Exceptions are explicit, named, scoped, and expiring. Silent exceptions do not
+    exist.
+19. Frameworks inform the methodology; they never replace engineering judgment or
+    dictate pipeline architecture.
+20. Explain the engineering decision, not just the pipeline code.
+
+---
+
+## 4. Workload context checklist
+
+Before designing or generating, resolve as much of this as the task requires. State
+assumptions for anything you could not resolve.
+
+| Factor | Why it matters |
+|---|---|
+| CI/CD platform | Determines syntax, identity model, and available primitives |
+| Application architecture | Monolith, service, function, library, job |
+| Language / runtime | Selects SAST and native test framework |
+| Package manager | Selects SCA and lockfile/pinning strategy |
+| Cloud provider | Identity federation, registry, policy engines |
+| Deployment platform | Kubernetes, serverless, VM, PaaS, package registry |
+| Artifact types produced | Drives container, IaC, and SBOM applicability |
+| Registries in use | Artifact governance, immutability, signing |
+| Existing security products | Existing-tool preference (`prefer_existing_tool`) |
+| Existing organizational processes | Ownership-boundary determinations |
+| Environment strategy | Where post-deployment validation can legally run |
+| Responsibility separation | Platform vs. application team ownership |
+| Risk tolerance / policy | Enforcement levels (BLOCK vs. WARN vs. REPORT) |
+| Compliance obligations | Additional controls, evidence retention |
+
+---
+
+## 5. Control selection algorithm
+
+Run this in order. It is the heart of the skill.
+
+```
+1. WORKLOAD INVENTORY
+   What is actually built, produced, stored, and deployed?
+
+2. APPLICABILITY TEST                     → per-rule `applicability`
+   For each rule: does the triggering technology, artifact, or risk exist?
+   NO → mark Not Applicable, record the reason (DSB-EVD-003). Stop.
+
+3. EXISTING-CAPABILITY CHECK              → tooling.prefer_existing_tool
+   Does an organizational tool already satisfy this capability?
+   YES → Satisfied by existing tool. Do NOT introduce a second one (DSB-SCAN-010).
+
+4. OWNERSHIP-BOUNDARY CHECK
+   Does another governed process legitimately own and enforce this control?
+   YES → Satisfied (externally owned: <named process>). Do not duplicate.
+
+5. ORGANIZATIONAL CONTEXT
+   Apply platform, policy, environment, and risk-tolerance factors to choose
+   enforcement level and placement.
+
+6. PLACEMENT
+   Earliest technically valid stage that produces meaningful results.
+```
+
+### The existing-tool decision pattern
+
+Use this exact shape when reconciling an organization's tools:
+
+```
+Required Capability:      Software Composition Analysis
+Existing Organizational
+Tool:                     Black Duck
+Decision:                 Use existing tool. Do not introduce a second SCA scanner.
+DSB Requirement:          DSB-SCAN-003 — Satisfied
+```
+
+---
+
+## 6. Enforcement model
+
+| Level | Meaning |
+|---|---|
+| **BLOCK** | Pipeline cannot continue without satisfaction or an approved exception. |
+| **WARN** | Surfaced to the team, non-blocking. |
+| **REPORT** | Evidence collected only; no signal on the pipeline result. |
+| **N/A** | Intentionally inapplicable to this workload, with a recorded justification. |
+
+Per-rule `enforcement.level` values are **DSB defaults and recommendations**. The
+organization's enforcement policy may adjust them. Never present a default as an
+immovable requirement — but always state what the DSB default is and what the
+organization is trading away by changing it.
+
+Exceptions are governed by `DSB-EXC-001` and `DSB-EXC-002`: named approver, documented
+scope, explicit expiry.
+
+Full detail: `references/enforcement-model.md`.
+
+---
+
+## 7. Output contract
+
+Every Advise, Design, and Review output includes, in this order:
+
+1. **Workload profile** — what you determined, and every assumption you made.
+2. **Phase mapping** — Build → Test → Scan → Deploy, with what lands in each.
+3. **Applicable controls** — rule ID, capability, placement, enforcement level, and the
+   tool satisfying it (existing or proposed).
+4. **Not Applicable** — every control excluded, each with its reason (`DSB-EVD-003`).
+   Never omit this section. An empty section is itself a finding.
+5. **Satisfied (externally owned)** — controls owned by another named process.
+6. **The deliverable** — advice, generated pipeline, or findings.
+7. **Rationale** — why these engineering decisions, with rule IDs.
+8. **Curriculum pointers** — the DSB topics a learner should study next.
+
+### Voice and teaching
+
+- Cite rule IDs inline. `DSB-SCAN-005`, not "a DSB rule about containers".
+- Teach the decision, not just the YAML. A pipeline the user cannot defend in a design
+  review is a failed output.
+- Name trade-offs honestly. If a control is expensive, slow, or noisy, say so.
+- Never invent a DSB rule ID. If no rule covers something, say it is outside the current
+  catalog.
+- Never introduce a vendor as a requirement. Tooling examples are illustrative, always.
+
+---
+
+## 8. Resources
+
+| File | Use it for |
+|---|---|
+| `rules/*.yaml` | The 42-rule catalog across 11 families — the authoritative requirements |
+| `references/applicability.md` | The five-step selection flow in full |
+| `references/capability-catalog.md` | Capability → applicability condition → earliest placement → owning rule |
+| `references/enforcement-model.md` | BLOCK / WARN / REPORT / N/A semantics and the exception path |
+| `references/framework-mappings.md` | NIST SSDF, SLSA, OWASP CI/CD, OWASP SAMM, CNCF cross-reference |
+| `examples/advise/` | Worked Advise output (Jenkins / Java / OpenShift enterprise) |
+| `examples/generate/` | Worked Generate outputs (GitHub Actions / Node / container, GitLab CI / Terraform) |
+| `examples/review/` | Worked Review output (Jenkinsfile, with compliant, non-compliant, and N/A findings) |
+
+Load `rules/*.yaml` whenever you need exact requirement text, applicability conditions,
+or enforcement defaults. Do not paraphrase a rule from memory when the catalog is
+available.
+
+---
+
+*Owned and maintained by The DevSec Blueprint. This skill is an implementation of DSB
+knowledge and standards, not the source of those standards.*

--- a/devsecops-engineering-skill/commands/advise.md
+++ b/devsecops-engineering-skill/commands/advise.md
@@ -1,0 +1,23 @@
+---
+description: Advise on a delivery pipeline using the DSB DevSecOps methodology — map existing capabilities to Build → Test → Scan → Deploy, find gaps, recommend enforcement.
+argument-hint: [architecture, toolset, or requirements — or leave blank to be asked]
+---
+
+Load the `devsecops-engineering` skill (`SKILL.md`) and its rule catalog (`rules/*.yaml`)
+before responding. This command is a thin entry point; all rule logic lives in the skill.
+
+Operate in **Mode 1 — Advise** (`SKILL.md` §2).
+
+Context supplied by the user:
+
+$ARGUMENTS
+
+If that is empty or too thin to work from, ask for the workload context checklist items
+in `SKILL.md` §4 that actually change the answer — not all of them.
+
+Do **not** produce pipeline code in this mode unless the user asks for it. If they want
+an implementation, direct them to `/devsecops-engineer:design`.
+
+Follow the output contract in `SKILL.md` §7 in full, including the Not Applicable
+section (`DSB-EVD-003`) and the Satisfied (externally owned) section. Cite rule IDs
+inline.

--- a/devsecops-engineering-skill/commands/assess.md
+++ b/devsecops-engineering-skill/commands/assess.md
@@ -1,0 +1,32 @@
+---
+description: Assess an existing pipeline, repository, or CI/CD config against the DSB rule catalog and return structured findings with remediation.
+argument-hint: [path to a pipeline file or repo, or paste the config]
+---
+
+Load the `devsecops-engineering` skill (`SKILL.md`) and its rule catalog (`rules/*.yaml`)
+before responding. This command is a thin entry point; all rule logic lives in the skill.
+
+Operate in **Mode 3 — Review** (`SKILL.md` §2).
+
+Target supplied by the user:
+
+$ARGUMENTS
+
+If a path is given, read it — and read the surrounding repository far enough to
+determine what the workload actually builds, since applicability depends on that and not
+on the pipeline's own claims. If the config was pasted with no repository access, work
+from it and state every assumption you had to make about the workload.
+
+Return findings in the fixed structure from `SKILL.md` §2, in this order:
+
+1. Satisfied controls
+2. Missing capabilities
+3. Inappropriate enforcement
+4. Duplicate tooling (`DSB-SCAN-010`)
+5. Pipeline security weaknesses — the pipeline as an attack surface
+6. Not Applicable, with justification (`DSB-EVD-003`)
+7. Remediation, ordered by risk, each tied to a rule ID
+
+Assess what the workload needs, not what a maximal pipeline would contain. A control the
+workload does not need is not a finding — it belongs in section 6. A control present but
+unnecessary belongs in section 4.

--- a/devsecops-engineering-skill/commands/design.md
+++ b/devsecops-engineering-skill/commands/design.md
@@ -1,0 +1,33 @@
+---
+description: Design and generate an implementation-ready DevSecOps pipeline for a stated workload, applying the DSB rule catalog with no unnecessary tooling.
+argument-hint: [platform, language, artifact type, deployment target]
+---
+
+Load the `devsecops-engineering` skill (`SKILL.md`) and its rule catalog (`rules/*.yaml`)
+before responding. This command is a thin entry point; all rule logic lives in the skill.
+
+Operate in **Mode 2 — Design / Generate** (`SKILL.md` §2).
+
+Context supplied by the user:
+
+$ARGUMENTS
+
+Before generating anything, resolve the workload context checklist (`SKILL.md` §4). Ask
+for what is missing and materially changes the design; for anything else, state an
+explicit assumption. Never silently guess.
+
+Then run the control selection algorithm (`SKILL.md` §5) and generate configuration for
+the user's **actual** platform. Annotate the generated code with rule IDs in comments so
+each control's justification travels with it.
+
+Hard constraints:
+
+- No scanner for a technology, artifact, or risk the workload does not have.
+- No second tool for a capability an existing organizational tool already covers
+  (`DSB-SCAN-010`).
+- No active DAST against production without explicit organizational authorization
+  (`DSB-SCAN-009`).
+- Pin third-party pipeline components to immutable references (`DSB-SC-002`).
+
+Follow the output contract in `SKILL.md` §7 in full, including the Not Applicable
+section (`DSB-EVD-003`).

--- a/devsecops-engineering-skill/docs/legal/TRADEMARKS.md
+++ b/devsecops-engineering-skill/docs/legal/TRADEMARKS.md
@@ -1,0 +1,79 @@
+# Trademarks and Branding
+
+## The short version
+
+The **code is MIT. The brand is not.**
+
+You may fork this repository, modify the rules, and ship your own version — that is what
+the MIT license grants. You may not present the result as being The DevSec Blueprint's,
+or as endorsed by it.
+
+---
+
+## What the MIT license covers
+
+Everything in this repository that is an implementation:
+
+- The rule catalog (`rules/`)
+- The skill definition (`SKILL.md`)
+- Command entry points (`commands/`)
+- Reference documentation (`references/`)
+- Worked examples (`examples/`)
+- Validation scripts (`scripts/`)
+
+Use, copy, modify, merge, publish, distribute, sublicense, and sell — under the terms in
+[`LICENSE`](../../LICENSE).
+
+---
+
+## What it does not cover
+
+The MIT license grants no trademark rights. The following remain the property of The
+DevSec Blueprint:
+
+| Asset | Includes |
+|---|---|
+| **Names** | "The DevSec Blueprint", "DevSec Blueprint", "DSB" as used to identify the project |
+| **Branding** | Logos, marks, visual identity, and design assets |
+| **Curriculum** | Learning paths, walkthroughs, quizzes, badges, and course content on the DSB platform |
+| **Domains and accounts** | DSB web properties, community spaces, and social presence |
+
+The `DSB-` rule ID prefix is part of the naming scheme. Forks that diverge from this
+catalog should adopt their own prefix so that a rule ID means one thing everywhere.
+
+---
+
+## Using the name
+
+**Permitted without asking** — factual, descriptive reference:
+
+- "Built on The DevSec Blueprint DevSecOps Engineering Skill"
+- "Implements DSB rule DSB-SCAN-003"
+- "A fork of the DSB DevSecOps Engineering Skill"
+- Linking to this repository or to DSB materials
+
+**Not permitted without written authorization:**
+
+- Presenting a fork or derivative as an official DSB project
+- Using DSB names or logos as your product's name, logo, or domain
+- Implying endorsement, partnership, certification, or affiliation
+- Using DSB branding in paid training, consulting, or certification offerings
+
+---
+
+## Why separate them
+
+The methodology is meant to be adopted, adapted, and argued with — MIT makes that
+frictionless, and a rule catalog nobody can fork is a rule catalog nobody improves.
+
+The brand exists so learners can tell what actually came from DSB. If any fork could
+carry the name, "DSB says" would stop meaning anything, and the guarantee behind the
+curriculum would be gone. Permissive code and a protected identity are complementary,
+not in tension.
+
+---
+
+## Questions
+
+Open an issue in this repository, or reach the maintainers through the channels listed in
+[`MAINTAINERS.md`](../../MAINTAINERS.md).

--- a/devsecops-engineering-skill/examples/advise/jenkins-java-enterprise.md
+++ b/devsecops-engineering-skill/examples/advise/jenkins-java-enterprise.md
@@ -1,0 +1,238 @@
+# Advise — Enterprise Java on Jenkins and OpenShift
+
+**Mode 1 — Advise.** No pipeline code is produced. This example demonstrates the
+existing-tool decision pattern, ownership boundaries, and explicit Not Applicable
+determinations.
+
+---
+
+## Scenario as supplied
+
+> We're an enterprise running Jenkins. Java services built with Maven, artifacts in
+> Artifactory, deployed to OpenShift. We already own Checkmarx, Black Duck, and Prisma
+> Cloud. Our platform team runs the OpenShift clusters and has admission policy in place.
+> What should our pipeline look like and what are we missing?
+
+---
+
+## 1. Workload profile
+
+| Factor | Determined | Source |
+|---|---|---|
+| CI/CD platform | Jenkins | Stated |
+| Language / build | Java, Maven | Stated |
+| Artifact type | JAR **and** container image | Inferred — OpenShift deployment requires an image |
+| Registry | Artifactory (JARs and images) | Stated |
+| Deployment platform | OpenShift (Kubernetes) | Stated |
+| Existing security products | Checkmarx (SAST), Black Duck (SCA), Prisma Cloud (container + IaC) | Stated |
+| Cluster policy ownership | Platform team, admission policy in place | Stated |
+
+**Assumptions made — confirm these:**
+
+1. Container images are built in this pipeline, not by an OpenShift BuildConfig. If the
+   cluster builds them, `DSB-SCAN-005` placement moves and `DSB-DEPLOY-002` needs
+   re-examination.
+2. A pre-production OpenShift environment exists and is representative enough to test
+   against.
+3. Kubernetes manifests or Helm charts live in the application repository. If the
+   platform team owns them, `DSB-SCAN-007` becomes externally owned.
+
+---
+
+## 2. Phase mapping
+
+```
+BUILD    Maven compile + package → JAR → container image → push to Artifactory
+TEST     JUnit via Maven Surefire; integration tests via Failsafe
+SCAN     Secrets → SAST → SCA → image scan → manifest scan → (post-deploy) DAST
+DEPLOY   Promote image by digest to OpenShift; verify; trigger runtime validation
+```
+
+---
+
+## 3. Applicable controls
+
+### The existing-tool decisions
+
+Your three products cover five capabilities. Nothing new needs buying.
+
+```
+Required Capability:      Static Application Security Testing
+Existing Organizational
+Tool:                     Checkmarx
+Decision:                 Use existing tool. Do not introduce a second SAST scanner.
+DSB Requirement:          DSB-SCAN-002 — Satisfied
+```
+
+```
+Required Capability:      Software Composition Analysis
+Existing Organizational
+Tool:                     Black Duck
+Decision:                 Use existing tool. Do not introduce a second SCA scanner.
+                          Notably: do NOT add OWASP Dependency-Check "for coverage" —
+                          that is a DSB-SCAN-010 violation, not defense in depth.
+DSB Requirement:          DSB-SCAN-003 — Satisfied
+```
+
+```
+Required Capability:      Container / Image Scanning
+Existing Organizational
+Tool:                     Prisma Cloud
+Decision:                 Use existing tool. Scan at build time in the pipeline AND rely
+                          on Prisma's registry scanning for drift on published images.
+                          This is not duplication — the two answer different questions
+                          ("should this ship?" vs. "is what shipped still safe?").
+DSB Requirement:          DSB-SCAN-005 — Satisfied
+```
+
+```
+Required Capability:      Infrastructure-as-Code Scanning
+Existing Organizational
+Tool:                     Prisma Cloud IaC
+Decision:                 Use existing tool, IF this repository contains IaC.
+                          See Not Applicable below — for a typical service repo it does not.
+DSB Requirement:          DSB-SCAN-006 — See §5
+```
+
+### Full control table
+
+| Rule | Capability | Tool | Placement | Enforcement |
+|---|---|---|---|---|
+| `DSB-SRC-002` | Branch protection | Jenkins + SCM | Merge to `main` | BLOCK |
+| `DSB-SCAN-004` | Secret scanning | **Gap — see §6** | Pre-merge + history | BLOCK |
+| `DSB-SCAN-002` | SAST | Checkmarx | Post-checkout, pre-build | BLOCK on High+ |
+| `DSB-BUILD-001` | Automated build | Jenkins + Maven | Build | BLOCK |
+| `DSB-BUILD-002` | Dependency integrity | Artifactory as the only Maven repo | Build | BLOCK |
+| `DSB-TEST-001` | Automated tests | Surefire / Failsafe | Test | BLOCK |
+| `DSB-SCAN-003` | SCA | Black Duck | After `mvn dependency:resolve` | BLOCK on High+ with fix |
+| `DSB-SC-001` | SBOM | Black Duck or CycloneDX Maven plugin | Build | REPORT |
+| `DSB-BUILD-003` | Artifact identity | Image digest + Maven version | Build | BLOCK |
+| `DSB-SCAN-005` | Image scanning | Prisma Cloud | After image build, before push | BLOCK on Critical |
+| `DSB-SCAN-007` | Manifest scanning | **See §4 — partly externally owned** | Pre-merge | WARN |
+| `DSB-SCAN-008` | Pipeline config scanning | **Gap — see §6** | Pre-merge | WARN |
+| `DSB-ART-001` | Governed registry | Artifactory | Publish | BLOCK |
+| `DSB-ART-002` | Artifact immutability | Artifactory immutable tags | Publish | BLOCK |
+| `DSB-DEPLOY-001` | Gate verification | Jenkins stage dependencies | Deploy | BLOCK |
+| `DSB-DEPLOY-002` | Deploy tested artifact | Digest-pinned image reference | Deploy | BLOCK |
+| `DSB-DEPLOY-003` | Authorized deployment | Jenkins input step + RBAC | Deploy to prod | BLOCK |
+| `DSB-DEPLOY-004` | Post-deploy verification | Smoke tests | After deploy | WARN |
+| `DSB-SCAN-009` | DAST | **Gap — see §6** | Post-deploy to pre-prod only | WARN |
+| `DSB-ID-002` | Least-privilege credentials | Jenkins credential scoping | Cross-cutting | BLOCK |
+| `DSB-ID-003` | Managed secrets | Jenkins Credentials or Vault | Cross-cutting | BLOCK |
+| `DSB-EVD-001` | Machine-readable evidence | JUnit XML, SARIF, CycloneDX | All gates | REPORT |
+
+---
+
+## 4. Satisfied (externally owned)
+
+```
+DSB-SCAN-007 — Kubernetes / workload configuration scanning
+Owning process:  Platform team's OpenShift admission policy (SCC + admission controller)
+Enforcement:     Workloads violating the baseline are rejected at admission
+Coverage check:  ✅ Applies to all namespaces this service deploys into
+Residual:        Admission rejects at deploy time, which is late feedback. Recommend a
+                 WARN-level manifest scan pre-merge so teams learn before the deploy
+                 fails — the platform control remains the enforcement point.
+```
+
+**This is the determination to scrutinize most.** Before accepting it, confirm all three:
+the process is *named*, it is *enforced* rather than merely available, and it covers
+*this* workload's namespaces. Two of three is a gap, not an external satisfaction.
+
+---
+
+## 5. Not Applicable
+
+Required by `DSB-EVD-003`. Every excluded control, with the workload fact that excludes
+it.
+
+| Rule | Determination | Reason |
+|---|---|---|
+| `DSB-SCAN-006` | **N/A** | This service repository contains no infrastructure-as-code. Cluster and cloud infrastructure is defined in the platform team's repositories, where it carries its own `DSB-IAC-*` obligations. *If your service repo does contain Terraform, this flips to Applicable with Prisma Cloud IaC.* |
+| `DSB-IAC-001` · `DSB-IAC-002` · `DSB-IAC-003` | **N/A** | No IaC in this repository. Same caveat as above. |
+| `DSB-ART-003` | **N/A** | Images are consumed only by your own OpenShift clusters from your own Artifactory instance — no cross-trust-boundary distribution, and no organizational signing policy stated. Revisit if you distribute externally or adopt a signing requirement. |
+| `DSB-SC-003` | **N/A** | Jenkins provides no native provenance attestation mechanism. Recorded as a platform limitation rather than an engineering choice — `DSB-BUILD-003` and `DSB-ART-004` carry the traceability burden instead. |
+
+---
+
+## 6. Gaps — what you are missing
+
+Ordered by risk.
+
+### Gap 1 — No secret scanning (`DSB-SCAN-004`, BLOCK)
+
+Your three products cover code, dependencies, and images. **None of them scans for
+committed credentials.** This is the most common gap in an otherwise mature enterprise
+toolchain, because the expensive products create a sense of coverage that does not extend
+here.
+
+`DSB-SCAN-004` is one of only two scan rules that is `always: true` — it carries no
+technology condition, because every repository can leak a credential regardless of what
+it builds.
+
+*Needs:* a secret-scanning capability covering both incoming changes and existing
+history. History matters — a secret deleted in a later commit is still live.
+
+### Gap 2 — No DAST or API security testing (`DSB-SCAN-009`, WARN)
+
+Java services on OpenShift expose HTTP interfaces. Nothing in your stack tests them at
+runtime.
+
+*Needs:* DAST against a **pre-production** environment, triggered by
+`DSB-DEPLOY-004` after deployment.
+
+> Active DAST against production requires explicit, documented organizational
+> authorization. Do not schedule it against production without that authorization in
+> hand.
+
+### Gap 3 — Jenkins pipeline configuration is unscanned (`DSB-SCAN-008`, WARN)
+
+Your Jenkinsfiles are code with credentials to Artifactory and OpenShift, and they are
+outside the scope of every scanner you own. Check specifically for: credentials bound at
+pipeline scope rather than stage scope, unpinned shared-library references, and
+`sh` steps interpolating values from SCM-controlled input.
+
+### Gap 4 — Verify `DSB-DEPLOY-002` compliance
+
+Confirm the OpenShift deployment references the image **digest** that Prisma scanned, not
+a mutable tag. If OpenShift resolves `:latest` or a moving tag at deploy time, every scan
+result you hold describes an image you may not be running.
+
+---
+
+## 7. Rationale
+
+**Why no new products.** You already own capability for five of the required controls.
+`DSB-SCAN-010` makes the minimum sufficient toolchain a requirement, not a preference:
+duplicate scanners multiply triage cost and slow the pipeline until teams start routing
+around it — which costs more security than the second scanner ever provided. Your gaps
+are all in capabilities nobody sold you, which is exactly where mature toolchains leak.
+
+**Why secret scanning ranks first.** It is the only gap where the risk is live from the
+moment of commit, needs no attacker sophistication, and is not remediated by the fix
+that appears to remediate it. SAST and SCA findings are potential; a committed credential
+is actual.
+
+**Why manifest scanning stays even though admission enforces it.** Admission control is
+the correct enforcement point and stays that way. The pre-merge scan is a feedback
+control — the same finding, ten minutes earlier, at WARN. Different placement, different
+purpose, and not a `DSB-SCAN-010` duplication because only one of the two gates.
+
+**Why enforcement is not uniform.** SAST and SCA BLOCK because findings are actionable
+and remediation exists. DAST WARNs because it is slow and noisy against a pre-production
+environment that may not fully represent production. Uniform BLOCK gates on noisy
+controls are how pipelines acquire `continue-on-error` — an undocumented, unapproved,
+unexpiring exception (`DSB-EXC-001`).
+
+---
+
+## 8. Curriculum pointers
+
+- DevSecOps Foundations — the Build → Test → Scan → Deploy model and why testing and
+  scanning are separate phases
+- Pipeline Security — CI/CD as production infrastructure and its own attack surface
+- Secrets Management — why history scanning is not optional and rotation is the only
+  real remediation
+- Container Security — image scanning placement, and build-time vs. registry scanning
+- Kubernetes Security — admission control as an enforcement point and ownership
+  boundaries between platform and application teams

--- a/devsecops-engineering-skill/examples/generate/github-actions-node-container.md
+++ b/devsecops-engineering-skill/examples/generate/github-actions-node-container.md
@@ -1,0 +1,396 @@
+# Generate — Node.js Container on GitHub Actions to EKS
+
+**Mode 2 — Design / Generate.** Implementation-ready configuration, annotated with rule
+IDs. Note what is *absent* as much as what is present.
+
+---
+
+## Scenario as supplied
+
+> Node.js API, TypeScript, npm. We build a container image, push to ECR, deploy to EKS.
+> GitHub Actions. No existing security tooling — greenfield. What should the pipeline be?
+
+---
+
+## 1. Workload profile
+
+| Factor | Determined |
+|---|---|
+| CI/CD platform | GitHub Actions |
+| Language / runtime | TypeScript on Node.js |
+| Package manager | npm (lockfile present) |
+| Artifact | Container image |
+| Registry | Amazon ECR |
+| Deployment platform | Amazon EKS |
+| Existing security tooling | None — greenfield |
+
+**Assumptions — confirm:**
+
+1. Kubernetes manifests live in this repository (`k8s/`). If a platform team owns them,
+   `DSB-SCAN-007` becomes Satisfied (externally owned).
+2. A `staging` environment exists and is representative enough for post-deploy testing.
+3. No organizational artifact-signing policy exists yet.
+
+Greenfield means every tool below is a proposal, not a reconciliation. If your
+organization later adopts a commercial SAST or SCA platform, replace the corresponding
+tool here — do not run both (`DSB-SCAN-010`).
+
+---
+
+## 2. Phase mapping
+
+```
+BUILD    npm ci (lockfile-pinned) → tsc → docker build → push by digest to ECR
+TEST     Jest unit + integration
+SCAN     Secrets → SAST → SCA → image scan → manifest scan → workflow scan → DAST
+DEPLOY   Deploy digest to EKS staging → verify → DAST → gated promotion to production
+```
+
+---
+
+## 3. The pipeline
+
+### `.github/workflows/delivery.yml`
+
+```yaml
+name: Delivery
+
+on:
+  pull_request:
+    branches: [main]
+  push:
+    branches: [main]
+
+# DSB-ID-002 — least privilege by default; jobs opt in to what they need.
+permissions:
+  contents: read
+
+concurrency:
+  group: delivery-${{ github.ref }}
+  cancel-in-progress: true
+
+env:
+  AWS_REGION: us-east-1
+  ECR_REPOSITORY: my-api
+
+jobs:
+  # ---------------------------------------------------------------------------
+  # SCAN (pre-merge) — controls needing only source. Earliest valid placement.
+  # ---------------------------------------------------------------------------
+  secret-scan:
+    # DSB-SCAN-004 — always applicable. Full history, not just the diff:
+    # a secret deleted in a later commit is still a live credential.
+    name: Secret scan
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@11bd71901bbe5b1630ceea73d27597364c9af683 # v4.2.2
+        with:
+          fetch-depth: 0 # required for history scanning
+      # DSB-SC-002 — third-party actions pinned to a commit SHA, not a tag.
+      - uses: gitleaks/gitleaks-action@83373cf2f8c4db6e24b41c1a9b086bb9619e9cd3 # v2.3.7
+        env:
+          GITLEAKS_ENABLE_SUMMARY: "true"
+
+  sast:
+    # DSB-SCAN-002 — first-party TypeScript exists.
+    name: SAST
+    runs-on: ubuntu-latest
+    permissions:
+      contents: read
+      security-events: write # DSB-EVD-001 — SARIF upload
+    steps:
+      - uses: actions/checkout@11bd71901bbe5b1630ceea73d27597364c9af683 # v4.2.2
+      - uses: github/codeql-action/init@48ab28a6f5dbc2a99bf1e0131198dd8f1df78169 # v3.28.0
+        with:
+          languages: javascript-typescript
+      - uses: github/codeql-action/analyze@48ab28a6f5dbc2a99bf1e0131198dd8f1df78169 # v3.28.0
+
+  workflow-scan:
+    # DSB-SCAN-008 — pipeline definitions are in the repository, so they are in
+    # scope. The pipeline holds ECR and EKS credentials; it is production
+    # infrastructure. WARN, not BLOCK — findings are advisory at this maturity.
+    name: Workflow config scan
+    runs-on: ubuntu-latest
+    continue-on-error: true # enforcement: WARN (DSB-SCAN-008 default)
+    steps:
+      - uses: actions/checkout@11bd71901bbe5b1630ceea73d27597364c9af683 # v4.2.2
+      - uses: zizmorcore/zizmor-action@5ca5fc7a4779c5263a3ffa0e1f693009994446d1 # v0.1.2
+
+  manifest-scan:
+    # DSB-SCAN-007 — Kubernetes manifests exist in this repository.
+    name: Kubernetes manifest scan
+    runs-on: ubuntu-latest
+    continue-on-error: true # enforcement: WARN
+    steps:
+      - uses: actions/checkout@11bd71901bbe5b1630ceea73d27597364c9af683 # v4.2.2
+      - uses: bridgecrewio/checkov-action@d6369fdf8a2897ebc8936a03ea82f61d6b28a166 # v12.2996.0
+        with:
+          directory: k8s/
+          framework: kubernetes
+          soft_fail: true
+
+  # ---------------------------------------------------------------------------
+  # BUILD + TEST + SCAN (artifact) — one job so the tested tree is the built tree.
+  # ---------------------------------------------------------------------------
+  build-test-scan:
+    name: Build, test, scan
+    runs-on: ubuntu-latest
+    needs: [secret-scan, sast]
+    permissions:
+      contents: read
+      id-token: write # DSB-ID-001 — OIDC federation, no static AWS keys
+    outputs:
+      image-digest: ${{ steps.push.outputs.digest }}
+    steps:
+      - uses: actions/checkout@11bd71901bbe5b1630ceea73d27597364c9af683 # v4.2.2
+
+      - uses: actions/setup-node@39370e3970a6d050c480ffad4ff0ed4d3fdee5af # v4.1.0
+        with:
+          node-version: '22'
+          cache: npm
+
+      # DSB-BUILD-002 — `npm ci` installs strictly from the committed lockfile
+      # with integrity hashes. `npm install` would resolve fresh and make the
+      # build non-deterministic.
+      - name: Install dependencies
+        run: npm ci
+
+      # DSB-SCAN-003 — SCA AFTER resolution. Scanning package.json before
+      # install sees direct dependencies only and misses the transitive
+      # majority, which is where most exploitable risk lives.
+      - name: SCA
+        run: npm audit --audit-level=high
+
+      # DSB-TEST-001 — project-native framework. DSB-TEST-002: this does not
+      # substitute for the scan phase, and the scans do not substitute for it.
+      - name: Test
+        run: npm test -- --ci --reporters=default --reporters=jest-junit
+
+      # DSB-EVD-001 — machine-readable evidence, retained.
+      - uses: actions/upload-artifact@6f51ac03b9356f520e9adb1b1b7802705f340c2b # v4.5.0
+        if: always()
+        with:
+          name: test-results
+          path: junit.xml
+          retention-days: 90
+
+      - name: Build application
+        run: npm run build
+
+      # DSB-ID-001 — short-lived credentials from OIDC federation. There is no
+      # long-lived AWS access key anywhere in this pipeline.
+      - uses: aws-actions/configure-aws-credentials@e3dd6a429d7300a6a4c196c26e071d42e0343502 # v4.0.2
+        with:
+          role-to-assume: ${{ vars.AWS_BUILD_ROLE_ARN }}
+          aws-region: ${{ env.AWS_REGION }}
+
+      - uses: aws-actions/amazon-ecr-login@062b18b96a7aff071d4dc91bc00c4c1a7945b076 # v2.0.1
+        id: ecr
+
+      # DSB-BUILD-003 — the image is identified by digest, traceable to this
+      # commit and this run.
+      - name: Build image
+        run: |
+          docker build \
+            --build-arg NODE_VERSION=22 \
+            -t "${{ steps.ecr.outputs.registry }}/${ECR_REPOSITORY}:${GITHUB_SHA}" \
+            .
+
+      # DSB-SCAN-005 — scan the built image BEFORE it is published. The base
+      # image contributes packages nobody on the team selected; this is the only
+      # point at which what actually ships is visible.
+      - name: Image scan
+        uses: aquasecurity/trivy-action@18f2510ee396bbf400402947b394f2dd8c87dbb0 # v0.29.0
+        with:
+          image-ref: ${{ steps.ecr.outputs.registry }}/${{ env.ECR_REPOSITORY }}:${{ github.sha }}
+          exit-code: '1'
+          severity: 'CRITICAL,HIGH'
+          ignore-unfixed: true # WARN-equivalent for findings with no available fix
+
+      # DSB-SC-001 — SBOM generated at build, when the resolved set is known.
+      - name: Generate SBOM
+        uses: anchore/sbom-action@f325610c9f50a54015d37c8d16cb3b0e2c8f4de0 # v0.18.0
+        with:
+          image: ${{ steps.ecr.outputs.registry }}/${{ env.ECR_REPOSITORY }}:${{ github.sha }}
+          format: cyclonedx-json
+          artifact-name: sbom.cdx.json
+
+      # DSB-DEPLOY-001 — publication happens only after every gate above passed.
+      - name: Push image
+        id: push
+        if: github.event_name == 'push' && github.ref == 'refs/heads/main'
+        run: |
+          IMAGE="${{ steps.ecr.outputs.registry }}/${ECR_REPOSITORY}"
+          docker push "${IMAGE}:${GITHUB_SHA}"
+          DIGEST=$(docker inspect --format='{{index .RepoDigests 0}}' "${IMAGE}:${GITHUB_SHA}" | cut -d@ -f2)
+          echo "digest=${DIGEST}" >> "$GITHUB_OUTPUT"
+
+  # ---------------------------------------------------------------------------
+  # DEPLOY
+  # ---------------------------------------------------------------------------
+  deploy-staging:
+    name: Deploy to staging
+    runs-on: ubuntu-latest
+    needs: [build-test-scan, workflow-scan, manifest-scan]
+    if: github.event_name == 'push' && github.ref == 'refs/heads/main'
+    environment: staging
+    permissions:
+      contents: read
+      id-token: write
+    steps:
+      - uses: actions/checkout@11bd71901bbe5b1630ceea73d27597364c9af683 # v4.2.2
+
+      - uses: aws-actions/configure-aws-credentials@e3dd6a429d7300a6a4c196c26e071d42e0343502 # v4.0.2
+        with:
+          # DSB-ID-002 — a deploy role, distinct from the build role.
+          role-to-assume: ${{ vars.AWS_STAGING_DEPLOY_ROLE_ARN }}
+          aws-region: ${{ env.AWS_REGION }}
+
+      # DSB-DEPLOY-002 — deploy by DIGEST. The image that was scanned is the
+      # image that runs. A mutable tag here would silently invalidate every scan
+      # result above.
+      - name: Deploy
+        env:
+          IMAGE_DIGEST: ${{ needs.build-test-scan.outputs.image-digest }}
+        run: |
+          aws eks update-kubeconfig --name staging-cluster
+          kubectl set image deployment/my-api \
+            api="${{ vars.ECR_REGISTRY }}/${ECR_REPOSITORY}@${IMAGE_DIGEST}"
+          kubectl rollout status deployment/my-api --timeout=5m
+
+      # DSB-DEPLOY-004 — deployment succeeding is not the system working.
+      - name: Smoke test
+        run: curl -fsS --retry 5 --retry-delay 10 "${{ vars.STAGING_URL }}/healthz"
+
+  dast:
+    # DSB-SCAN-009 — runtime-dependent, so it runs after deployment. It remains
+    # part of Scan/verification, not a fifth phase.
+    #
+    # STAGING ONLY. Active DAST against production requires explicit, documented
+    # organizational authorization. This job must never be pointed at the
+    # production URL without it.
+    name: DAST (staging)
+    runs-on: ubuntu-latest
+    needs: [deploy-staging]
+    continue-on-error: true # enforcement: WARN — slow and noisy by nature
+    steps:
+      - uses: zaproxy/action-baseline@7c4deb10e6261301961c86d65d54a516394f9aed # v0.14.0
+        with:
+          target: ${{ vars.STAGING_URL }}
+
+  deploy-production:
+    name: Deploy to production
+    runs-on: ubuntu-latest
+    needs: [deploy-staging, dast]
+    # DSB-DEPLOY-003 — the `production` environment carries required reviewers,
+    # so this records who authorized the deployment, of which artifact, from
+    # which commit.
+    environment: production
+    permissions:
+      contents: read
+      id-token: write
+    steps:
+      - uses: aws-actions/configure-aws-credentials@e3dd6a429d7300a6a4c196c26e071d42e0343502 # v4.0.2
+        with:
+          role-to-assume: ${{ vars.AWS_PROD_DEPLOY_ROLE_ARN }}
+          aws-region: ${{ env.AWS_REGION }}
+
+      # DSB-DEPLOY-002 — the SAME digest that passed staging. Not a rebuild.
+      - name: Promote
+        env:
+          IMAGE_DIGEST: ${{ needs.build-test-scan.outputs.image-digest }}
+        run: |
+          aws eks update-kubeconfig --name production-cluster
+          kubectl set image deployment/my-api \
+            api="${{ vars.ECR_REGISTRY }}/${ECR_REPOSITORY}@${IMAGE_DIGEST}"
+          kubectl rollout status deployment/my-api --timeout=10m
+```
+
+---
+
+## 4. Supporting configuration
+
+### `.github/CODEOWNERS`
+
+```
+# DSB-SRC-003 — security-relevant paths require review by someone who owns them.
+# Without this, the controls above can be edited by anyone with write access.
+/.github/workflows/   @devsecblueprint/security
+/k8s/                 @devsecblueprint/platform
+/Dockerfile           @devsecblueprint/security
+```
+
+### Branch protection (`DSB-SRC-002`)
+
+Configure on `main` — this is the enforcement point that makes every gate above
+unavoidable:
+
+- Require a pull request with at least one approving review
+- Require status checks: `secret-scan`, `sast`, `build-test-scan`
+- Prevent direct pushes, including for administrators
+
+Without branch protection, all of the above is advisory: any contributor can push
+directly to `main` and skip it entirely.
+
+---
+
+## 5. Not Applicable
+
+Required by `DSB-EVD-003`.
+
+| Rule | Determination | Reason |
+|---|---|---|
+| `DSB-SCAN-006` | **N/A** | No infrastructure-as-code in this repository. The EKS cluster and ECR repository are provisioned elsewhere. Flips to Applicable the moment a `terraform/` directory appears. |
+| `DSB-IAC-001` · `DSB-IAC-002` · `DSB-IAC-003` | **N/A** | No IaC in this repository. |
+| `DSB-ART-003` | **N/A** | No organizational signing policy, and images are consumed only by your own EKS clusters from your own ECR — no cross-trust-boundary distribution. Revisit when either changes. |
+| `DSB-SC-003` | **Deferred, not N/A** | GitHub Actions *does* support provenance attestation, so the platform condition is met. Omitted from v1 of this pipeline as a deliberate sequencing choice, which makes it a gap rather than a Not Applicable. Add `actions/attest-build-provenance` with verification at deploy — generating provenance without verifying it provides no security value. |
+
+The `DSB-SC-003` row is the important one. It is the difference between "the workload
+makes this meaningless" (N/A) and "we chose not to do it yet" (a gap, and if it bypasses
+a BLOCK gate, an exception under `DSB-EXC-001`).
+
+---
+
+## 6. Rationale
+
+**Why `npm ci` and not `npm install`.** `npm install` may resolve versions not in the
+lockfile, so the tree you scanned is not necessarily the tree you built. `npm ci` fails
+if the lockfile and manifest disagree — a deterministic build is what makes every
+downstream scan result meaningful (`DSB-BUILD-002`).
+
+**Why SCA runs after install.** Scanning `package.json` sees direct dependencies only.
+Most exploitable risk arrives transitively, through packages nobody explicitly chose.
+This is the most common placement error in the catalog.
+
+**Why every action is SHA-pinned.** A tag is mutable. `@v4` resolves to whatever the
+maintainer's account pushes there, which makes it remote code execution scheduled for
+whenever that account is compromised. `DSB-SC-002` requires immutable references; use
+Dependabot or Renovate to keep the pins moving deliberately.
+
+**Why build and test are one job.** Splitting them means re-checkout and re-install, and
+the tested tree is then not provably the built tree. One job keeps `DSB-DEPLOY-002`
+honest end to end.
+
+**Why deploy by digest.** A tag can be overwritten. The digest is the artifact. Every
+scan result above describes exactly one digest; deploying anything else discards them
+all silently.
+
+**Why DAST is WARN and staging-only.** DAST is slow and noisy, and staging is not
+production, so findings need triage rather than an automatic stop. Staging-only is not a
+preference — active scanning against production is operationally indistinguishable from
+an attack and requires explicit organizational authorization.
+
+**Why there is no second SAST or SCA tool.** `DSB-SCAN-010`. One tool per capability.
+Adding Semgrep alongside CodeQL, or Snyk alongside `npm audit`, multiplies triage cost
+without adding assurance — and a pipeline slow enough to route around is a net security
+loss.
+
+---
+
+## 7. Curriculum pointers
+
+- CI/CD Fundamentals — job dependencies, gating, and why the four phases exist
+- Supply Chain Security — lockfiles, SHA pinning, SBOM, and provenance
+- Container Security — image scanning placement and base image selection
+- Cloud Identity — OIDC federation and eliminating static cloud credentials
+- Kubernetes Security — digest-pinned deployments and admission policy

--- a/devsecops-engineering-skill/examples/generate/gitlab-ci-terraform.md
+++ b/devsecops-engineering-skill/examples/generate/gitlab-ci-terraform.md
@@ -1,0 +1,333 @@
+# Generate — Terraform on GitLab CI
+
+**Mode 2 — Design / Generate.** An infrastructure workload. Note how different the
+applicable control set is from the application example — this is the selection algorithm
+doing its job, not a weaker pipeline.
+
+---
+
+## Scenario as supplied
+
+> Terraform for our AWS environments, GitLab CI, self-hosted GitLab. Separate state per
+> environment in S3. We want the same rigor we apply to application code.
+
+---
+
+## 1. Workload profile
+
+| Factor | Determined |
+|---|---|
+| CI/CD platform | GitLab CI (self-hosted) |
+| Workload type | Infrastructure-as-code (Terraform) |
+| Cloud | AWS |
+| State backend | S3, separate per environment |
+| Artifact | Terraform plan file — not a distributable artifact |
+| Deployment | `terraform apply` to AWS environments |
+| Existing security tooling | None stated |
+
+**Assumptions — confirm:**
+
+1. GitLab is configured as an OIDC identity provider trusted by AWS IAM. If not,
+   `DSB-ID-001` is the first thing to fix — it precedes everything else here.
+2. State locking is configured (DynamoDB table or S3 native locking).
+3. Environments are `dev`, `staging`, `production`, with production requiring approval.
+
+---
+
+## 2. Phase mapping
+
+Infrastructure follows the same four phases (`DSB-IAC-001`). The activities differ; the
+structure does not.
+
+```
+BUILD    terraform init + validate + fmt — the deliverable is a valid configuration
+TEST     Contract/policy tests where meaningful test surface exists
+SCAN     Secret scan → IaC scan → plan-aware policy evaluation
+DEPLOY   Plan → review → gated apply → post-apply verification
+```
+
+The most important difference from an application pipeline: **the plan is the review
+artifact, and apply is the irreversible step.** Everything upstream exists to make the
+plan trustworthy.
+
+---
+
+## 3. The pipeline
+
+> **Digests below are placeholders.** `DSB-SC-002` requires pinning by digest, and the
+> configuration demonstrates that shape — but resolve the real digests for the versions
+> you adopt before use (`docker buildx imagetools inspect <image>:<tag>`). A copied
+> placeholder digest will simply fail to pull, which is the safe failure mode, but do not
+> mistake these for verified pins.
+
+### `.gitlab-ci.yml`
+
+```yaml
+stages:
+  - scan
+  - build
+  - plan
+  - apply
+
+variables:
+  TF_VERSION: "1.10.3"
+  TF_IN_AUTOMATION: "true"
+  # DSB-EVD-002 — plan output is reviewed by humans; keep it readable but
+  # never let it echo secret values.
+  TF_CLI_ARGS: "-no-color"
+
+default:
+  # DSB-SC-002 — image pinned by digest, not by tag. A tag is mutable and this
+  # image executes with credentials that can change your entire estate.
+  image:
+    name: hashicorp/terraform:1.10.3@sha256:6f8e4c7c1e8b4d3f2a1c9e0b7d6a5f4e3c2b1a0f9e8d7c6b5a4f3e2d1c0b9a8f
+    entrypoint: [""]
+
+# DSB-ID-001 — short-lived credentials via GitLab OIDC. No AWS access keys in
+# CI/CD variables anywhere in this pipeline.
+.aws_oidc: &aws_oidc
+  id_tokens:
+    AWS_ID_TOKEN:
+      aud: https://gitlab.example.com
+  before_script:
+    - >
+      export AWS_WEB_IDENTITY_TOKEN_FILE=$(mktemp);
+      echo "${AWS_ID_TOKEN}" > "${AWS_WEB_IDENTITY_TOKEN_FILE}";
+      export AWS_ROLE_ARN="${TF_ROLE_ARN}";
+      export AWS_DEFAULT_REGION="${AWS_REGION}"
+
+# -----------------------------------------------------------------------------
+# SCAN — needs only the source. Earliest valid placement.
+# -----------------------------------------------------------------------------
+secret-scan:
+  # DSB-SCAN-004 — always applicable. Terraform repositories are a high-value
+  # target for this specifically: variable files and state fragments are where
+  # credentials most often get committed by accident.
+  stage: scan
+  image:
+    name: zricethezav/gitleaks:v8.24.0@sha256:d4d6e0b0e0d1e5f7a8b9c0d1e2f3a4b5c6d7e8f9a0b1c2d3e4f5a6b7c8d9e0f1
+    entrypoint: [""]
+  script:
+    - gitleaks detect --source . --redact --report-format sarif --report-path gitleaks.sarif
+  artifacts:
+    when: always
+    # DSB-EVD-001 — machine-readable evidence, retained.
+    reports:
+      sast: gitleaks.sarif
+    expire_in: 90 days
+
+iac-scan:
+  # DSB-SCAN-006 — the repository IS infrastructure-as-code. This is the primary
+  # scan control for this workload, where SAST would be for an application.
+  stage: scan
+  image:
+    name: bridgecrew/checkov:3.2.334@sha256:9c8b7a6d5e4f3a2b1c0d9e8f7a6b5c4d3e2f1a0b9c8d7e6f5a4b3c2d1e0f9a8b
+    entrypoint: [""]
+  script:
+    - checkov -d . --framework terraform --output cli --output sarif --output-file-path console,checkov.sarif
+  artifacts:
+    when: always
+    reports:
+      sast: checkov.sarif
+    expire_in: 90 days
+  # DSB-SCAN-006 default is BLOCK. Retained: an IaC misconfiguration is
+  # provisioned risk — a public bucket is created correctly and instantly by a
+  # working pipeline.
+
+pipeline-scan:
+  # DSB-SCAN-008 — the pipeline definition is in the repository and holds a role
+  # that can modify the entire AWS estate.
+  stage: scan
+  image:
+    name: bridgecrew/checkov:3.2.334@sha256:9c8b7a6d5e4f3a2b1c0d9e8f7a6b5c4d3e2f1a0b9c8d7e6f5a4b3c2d1e0f9a8b
+    entrypoint: [""]
+  script:
+    - checkov -f .gitlab-ci.yml --framework gitlab_ci --soft-fail
+  allow_failure: true # enforcement: WARN (DSB-SCAN-008 default)
+
+# -----------------------------------------------------------------------------
+# BUILD — for IaC, "build" means producing a valid, initialized configuration.
+# -----------------------------------------------------------------------------
+validate:
+  # DSB-IAC-001 — infrastructure is a deliverable and gets the same treatment.
+  # DSB-BUILD-002 — the committed .terraform.lock.hcl pins provider versions and
+  # verifies their checksums. Without it, two runs can resolve different providers.
+  stage: build
+  <<: *aws_oidc
+  script:
+    - terraform init -backend=false
+    - terraform validate
+    - terraform fmt -check -recursive
+
+# -----------------------------------------------------------------------------
+# PLAN — the review artifact. DSB-IAC-002.
+# -----------------------------------------------------------------------------
+.plan_template: &plan_template
+  stage: plan
+  <<: *aws_oidc
+  script:
+    # DSB-IAC-003 — remote state, encrypted, access-controlled, locked. State is
+    # never committed: it commonly contains secrets and always contains a
+    # complete map of the environment.
+    - terraform init -backend-config="key=${TF_ENVIRONMENT}/terraform.tfstate"
+    - terraform plan -out=tfplan -input=false
+    # A binary plan is not reviewable. The JSON form is what policy evaluation
+    # and human review actually consume.
+    - terraform show -json tfplan > tfplan.json
+    # DSB-IAC-002 — policy evaluated against the PLAN, not the source. This
+    # catches what the change will actually do, including resource replacements
+    # that read as a one-line attribute edit in the diff.
+    - checkov -f tfplan.json --framework terraform_plan --soft-fail
+  artifacts:
+    paths:
+      - tfplan
+      - tfplan.json
+    # DSB-DEPLOY-002 — apply consumes THIS plan file. Re-planning at apply time
+    # would apply something nobody reviewed.
+    expire_in: 7 days
+
+plan:dev:
+  <<: *plan_template
+  variables:
+    TF_ENVIRONMENT: dev
+    TF_ROLE_ARN: ${AWS_DEV_PLAN_ROLE_ARN}
+  environment:
+    name: dev
+    action: prepare
+
+plan:production:
+  <<: *plan_template
+  variables:
+    TF_ENVIRONMENT: production
+    # DSB-ID-002 — a read-only plan role, distinct from the apply role. A plan
+    # job never needs write access.
+    TF_ROLE_ARN: ${AWS_PROD_PLAN_ROLE_ARN}
+  environment:
+    name: production
+    action: prepare
+  rules:
+    - if: $CI_COMMIT_BRANCH == $CI_DEFAULT_BRANCH
+
+# -----------------------------------------------------------------------------
+# APPLY — the irreversible step.
+# -----------------------------------------------------------------------------
+apply:dev:
+  # DSB-DEPLOY-001 — every upstream gate must have passed.
+  stage: apply
+  <<: *aws_oidc
+  needs: [secret-scan, iac-scan, validate, "plan:dev"]
+  variables:
+    TF_ENVIRONMENT: dev
+    TF_ROLE_ARN: ${AWS_DEV_APPLY_ROLE_ARN}
+  script:
+    - terraform init -backend-config="key=${TF_ENVIRONMENT}/terraform.tfstate"
+    # DSB-DEPLOY-002 — apply the reviewed plan file. Never `terraform apply`
+    # without a plan argument: that re-plans against current state and can apply
+    # changes that appeared after review.
+    - terraform apply -input=false tfplan
+  environment:
+    name: dev
+  rules:
+    - if: $CI_COMMIT_BRANCH == $CI_DEFAULT_BRANCH
+
+apply:production:
+  stage: apply
+  <<: *aws_oidc
+  needs: [secret-scan, iac-scan, validate, "plan:production"]
+  variables:
+    TF_ENVIRONMENT: production
+    TF_ROLE_ARN: ${AWS_PROD_APPLY_ROLE_ARN}
+  script:
+    - terraform init -backend-config="key=${TF_ENVIRONMENT}/terraform.tfstate"
+    - terraform apply -input=false tfplan
+    # DSB-DEPLOY-004 — verify the change took effect as planned.
+    - terraform plan -detailed-exitcode -input=false || test $? -ne 2
+  environment:
+    name: production
+  rules:
+    - if: $CI_COMMIT_BRANCH == $CI_DEFAULT_BRANCH
+      # DSB-DEPLOY-003 — manual gate plus GitLab protected-environment approval
+      # records who authorized this apply, of which plan, from which commit.
+      when: manual
+  allow_failure: false
+```
+
+---
+
+## 4. Supporting configuration
+
+### `CODEOWNERS` (`DSB-SRC-003`)
+
+```
+# Security-relevant paths require review by their owners.
+/.gitlab-ci.yml          @security-team
+/modules/iam/            @security-team
+/environments/production/ @platform-leads @security-team
+```
+
+### Protected branches and environments (`DSB-SRC-002`, `DSB-DEPLOY-003`)
+
+- `main` protected: no direct push, merge request required, pipeline must succeed
+- `production` as a protected environment with a designated approver group
+- The apply roles assumable **only** by the pipeline identity, never by humans
+
+That last point is what makes the pipeline the sole path to change. If engineers can
+assume the apply role directly, every control above becomes optional.
+
+---
+
+## 5. Not Applicable
+
+Required by `DSB-EVD-003`. This workload excludes more controls than the application
+example — because it genuinely does less, not because it is held to a lower standard.
+
+| Rule | Determination | Reason |
+|---|---|---|
+| `DSB-SCAN-002` | **N/A** | No first-party application source code. Terraform configuration is covered by `DSB-SCAN-006`, which is the correct control for it — running a SAST tool here would produce noise, not assurance. |
+| `DSB-SCAN-005` | **N/A** | No container image is produced. The pinned Terraform runner image is a build input, governed by `DSB-SC-002`, not a deliverable. |
+| `DSB-SCAN-007` | **N/A** | No Kubernetes manifests in this repository. Flips to Applicable if EKS workload definitions are added. |
+| `DSB-SCAN-009` | **N/A** | This workload exposes no runtime interface. It provisions infrastructure that may host services with their own interfaces; those services carry `DSB-SCAN-009` in their own pipelines. |
+| `DSB-DEPLOY-004` (full form) | **Partial** | No application to smoke-test. Satisfied in the reduced form of a post-apply drift check, which is the meaningful equivalent for this workload. |
+| `DSB-ART-001` · `DSB-ART-002` · `DSB-ART-003` · `DSB-ART-004` | **N/A** | No distributable artifact is produced. The plan file is an intra-pipeline intermediate, not a promoted artifact. *If you publish reusable Terraform modules to a registry, all four become Applicable.* |
+| `DSB-SC-001` | **N/A** | No released artifact to describe. Provider dependencies are pinned and checksum-verified by `.terraform.lock.hcl` under `DSB-BUILD-002`. |
+| `DSB-SC-003` | **N/A** | No released artifact for which to generate provenance. |
+| `DSB-TEST-001` | **Conditional** | Applicable if the repository contains reusable modules with contract-testable behavior. For an environment-composition repository, `terraform validate` plus plan review is the meaningful validation surface — writing assertions that a resource block contains the values it literally contains would be a `DSB-TEST-003` violation. |
+
+---
+
+## 6. Rationale
+
+**Why the plan is the review artifact.** Terraform diffs routinely hide destructive
+changes — a resource *replacement* can read as a one-line attribute edit in the source.
+The plan is the only artifact showing what will actually happen, which is why policy
+evaluation runs against `tfplan.json` and not against the `.tf` files alone.
+
+**Why `terraform apply tfplan` and never bare `terraform apply`.** A bare apply re-plans
+against current state at apply time and can execute changes that appeared after the
+review. Applying the saved plan is the IaC equivalent of `DSB-DEPLOY-002` — deploy the
+artifact that was reviewed, not a fresh one.
+
+**Why separate plan and apply roles.** A plan needs read access only. Splitting them
+means a compromised merge request can, at worst, read your infrastructure layout — it
+cannot change it (`DSB-ID-002`).
+
+**Why the state backend rules are BLOCK.** State files commonly contain secrets in
+plaintext and always contain a complete map of the environment. Unlocked state
+additionally lets two concurrent applies corrupt the environment outright, which is a
+correctness failure before it is a security one.
+
+**Why so many controls are N/A here.** This is the selection algorithm working. Applying
+container scanning to a repository that builds no container produces zero findings, zero
+assurance, and real pipeline latency — and teaches the team the gates are theatre. Nine
+Not Applicable determinations, each written down and each automatically wrong the moment
+the workload changes, is a stronger position than nine scanners that find nothing.
+
+---
+
+## 7. Curriculum pointers
+
+- Infrastructure as Code — Terraform delivery patterns and plan-review discipline
+- Cloud Identity — OIDC federation from CI/CD to AWS IAM
+- Policy as Code — evaluating plan output rather than source
+- State Management — remote backends, encryption, and locking
+- DevSecOps Foundations — why the four phases apply identically to infrastructure

--- a/devsecops-engineering-skill/examples/review/jenkinsfile-review.md
+++ b/devsecops-engineering-skill/examples/review/jenkinsfile-review.md
@@ -1,0 +1,329 @@
+# Review — Jenkinsfile Assessment
+
+**Mode 3 — Review.** Demonstrates the fixed findings structure with compliant,
+non-compliant, and Not Applicable outcomes in a single assessment.
+
+---
+
+## Pipeline under review
+
+```groovy
+pipeline {
+    agent any
+
+    environment {
+        AWS_ACCESS_KEY_ID     = credentials('aws-access-key')
+        AWS_SECRET_ACCESS_KEY = credentials('aws-secret-key')
+        REGISTRY              = 'registry.example.com'
+        SONAR_TOKEN           = credentials('sonar-token')
+    }
+
+    stages {
+        stage('Checkout') {
+            steps { checkout scm }
+        }
+
+        stage('Build') {
+            steps { sh 'mvn clean package -DskipTests' }
+        }
+
+        stage('SonarQube') {
+            steps {
+                sh 'mvn sonar:sonar -Dsonar.login=$SONAR_TOKEN'
+            }
+        }
+
+        stage('Dependency Check') {
+            steps {
+                sh 'mvn org.owasp:dependency-check-maven:check'
+                sh 'snyk test --severity-threshold=high || true'
+            }
+        }
+
+        stage('Docker Build') {
+            steps {
+                sh """
+                    docker build -t ${REGISTRY}/myapp:latest .
+                    docker push ${REGISTRY}/myapp:latest
+                """
+            }
+        }
+
+        stage('Deploy') {
+            steps {
+                sh 'kubectl set image deployment/myapp app=${REGISTRY}/myapp:latest'
+            }
+        }
+    }
+}
+```
+
+**Workload determined:** Java/Maven service, containerized, deployed to Kubernetes.
+No IaC in the repository. No Kubernetes manifests in the repository (deployment is
+imperative).
+
+---
+
+## 1. Satisfied controls
+
+Real credit where it is due — these are correctly present.
+
+| Rule | Control | How it is satisfied |
+|---|---|---|
+| `DSB-BUILD-001` | Automated build from source control | Jenkins builds from SCM checkout, not from a workstation |
+| `DSB-SCAN-001` | Scan phase present | SonarQube and dependency scanning both execute |
+| `DSB-SCAN-002` | SAST | SonarQube covers the Java source |
+| `DSB-SCAN-003` | SCA | OWASP Dependency-Check runs — see finding 4 on the duplication |
+| `DSB-ID-003` | Secrets from a managed store | Jenkins Credentials, not hardcoded values |
+| `DSB-ART-001` | Governed registry | Images publish to an organizational registry, not ad hoc storage |
+
+---
+
+## 2. Missing capabilities
+
+Applicable to this workload, absent from the pipeline.
+
+### 2.1 — No test execution (`DSB-TEST-001`, BLOCK) — **critical**
+
+```groovy
+sh 'mvn clean package -DskipTests'
+```
+
+`-DskipTests` is explicit. This pipeline never validates that the application works. Two
+rules fail:
+
+- `DSB-TEST-001` — no automated tests execute
+- `DSB-TEST-002` — SonarQube and Dependency-Check are being relied on as though they
+  constituted the Test phase. They do not. A SAST finding tells you nothing about whether
+  the feature works.
+
+This is the highest-severity finding in the review. Every other gate assumes a working
+application.
+
+### 2.2 — No secret scanning (`DSB-SCAN-004`, BLOCK)
+
+`DSB-SCAN-004` is `always: true` — it carries no technology condition. Nothing here scans
+for committed credentials, in the diff or in history.
+
+### 2.3 — No container image scanning (`DSB-SCAN-005`, BLOCK)
+
+The pipeline builds and pushes a container image and never scans it. The base image
+contributes packages nobody on the team selected; this pipeline has no visibility into
+what actually ships.
+
+Placement: after `docker build`, **before** `docker push`.
+
+### 2.4 — No SBOM (`DSB-SC-001`, WARN)
+
+An artifact is released with no bill of materials. When the next widely-exploited library
+CVE lands, answering "are we affected?" for this service is a manual investigation
+instead of a query.
+
+### 2.5 — No post-deployment verification (`DSB-DEPLOY-004`, WARN)
+
+`kubectl set image` returns as soon as the API accepts the update. The pipeline reports
+success whether or not the rollout completes or the pods become healthy.
+
+### 2.6 — No DAST (`DSB-SCAN-009`, WARN)
+
+A Java service on Kubernetes exposes an HTTP interface, and nothing tests it at runtime.
+Add against a pre-production environment only — active testing against production
+requires explicit organizational authorization.
+
+---
+
+## 3. Inappropriate enforcement
+
+### 3.1 — Snyk cannot fail the build (`DSB-EXC-001`, BLOCK) — **critical**
+
+```groovy
+sh 'snyk test --severity-threshold=high || true'
+```
+
+`|| true` discards the exit code. This is an **undocumented, unapproved, unscoped,
+non-expiring exception** to a BLOCK-level control. Every field `DSB-EXC-001` requires is
+absent: no named approver, no scope, no justification, no expiry.
+
+This is worse than not running Snyk. The stage reports green, so the pipeline looks like
+it has SCA enforcement it does not have.
+
+**Remediation:** either enforce it, or record a real exception with all five fields. If
+the problem is unfixable transitive findings, scope the exception to those specifically —
+not to the entire control.
+
+### 3.2 — SonarQube results do not gate (`DSB-SCAN-002`, BLOCK)
+
+`mvn sonar:sonar` submits results and exits successfully regardless of the quality gate
+outcome. Findings are produced but nothing acts on them. This is REPORT-level behavior
+where `DSB-SCAN-002` defaults to BLOCK — and, unlike a deliberate downgrade, it is
+almost certainly unintentional.
+
+### 3.3 — Deployment requires no authorization (`DSB-DEPLOY-003`, BLOCK)
+
+Any merge deploys straight to what appears to be a production cluster, with no approval
+gate and no record of who authorized it. Nothing in the pipeline distinguishes
+environments at all.
+
+---
+
+## 4. Duplicate tooling (`DSB-SCAN-010`, WARN)
+
+```groovy
+sh 'mvn org.owasp:dependency-check-maven:check'
+sh 'snyk test --severity-threshold=high || true'
+```
+
+**Two SCA tools for one capability.** `DSB-SCAN-010` requires the minimum sufficient
+toolchain. This costs build time and doubles triage on largely overlapping findings, and
+one of the two cannot fail the build anyway (finding 3.1).
+
+**Decision required:** pick one.
+
+```
+Required Capability:      Software Composition Analysis
+Candidate tools:          OWASP Dependency-Check (free, noisier, no fix guidance)
+                          Snyk (commercial, better remediation data, licence cost)
+Decision:                 Choose ONE based on your licensing position.
+                          Retire the other entirely — do not leave it running unenforced.
+DSB Requirement:          DSB-SCAN-003 — will be Satisfied by whichever is retained
+```
+
+Two scanners where one cannot fail the build is not defense in depth. It is one scanner
+plus latency.
+
+---
+
+## 5. Pipeline security weaknesses
+
+The pipeline as an attack surface (`DSB-SCAN-008`, and Principle 16).
+
+### 5.1 — Long-lived static AWS credentials (`DSB-ID-001`, BLOCK) — **critical**
+
+```groovy
+AWS_ACCESS_KEY_ID     = credentials('aws-access-key')
+AWS_SECRET_ACCESS_KEY = credentials('aws-secret-key')
+```
+
+Static AWS keys, exposed as environment variables to **every stage**. Any compromised
+dependency in the Maven build — or any `sh` step — can read them, and they remain valid
+indefinitely after exfiltration.
+
+**Remediation:** federated workload identity (Jenkins OIDC → AWS IAM role) issuing
+short-lived credentials.
+
+### 5.2 — Credentials bound at pipeline scope (`DSB-ID-002`, BLOCK)
+
+Every credential in the `environment` block is available to every stage. The build stage
+holds registry and cloud credentials it has no need for — so a poisoned build dependency
+reaches production directly. Bind credentials inside the stage that needs them.
+
+### 5.3 — `agent any` (`DSB-BUILD-004`, WARN)
+
+Builds run on any available agent, with no isolation or ephemerality guarantee. On a
+persistent shared agent, workspace remnants and cached credentials survive between
+builds — including between builds of *different projects*.
+
+### 5.4 — Unpinned base image (`DSB-SC-002`, BLOCK)
+
+Not visible in the Jenkinsfile, but verify the `Dockerfile`: base images must be pinned
+by digest.
+
+### 5.5 — Pipeline definition is unscanned (`DSB-SCAN-008`, WARN)
+
+The Jenkinsfile is in the repository and is in scope for scanning. It has never been
+scanned — which is why findings 5.1 through 5.3 went unnoticed.
+
+---
+
+## 6. Not Applicable
+
+Required by `DSB-EVD-003`. These controls are absent **correctly** — their absence is not
+a finding.
+
+| Rule | Determination | Reason |
+|---|---|---|
+| `DSB-SCAN-006` | **N/A** | No infrastructure-as-code in this repository |
+| `DSB-IAC-001` · `DSB-IAC-002` · `DSB-IAC-003` | **N/A** | No IaC in this repository |
+| `DSB-SCAN-007` | **N/A** | No Kubernetes manifests in the repository — deployment is imperative via `kubectl set image`. *This is itself a `DSB-SRC-001` finding: the deployment configuration is not in version control. Declarative manifests would fix that and make `DSB-SCAN-007` Applicable — a net improvement.* |
+| `DSB-ART-003` | **N/A** | No organizational signing policy stated; images stay within one governed registry |
+| `DSB-SC-003` | **N/A** | Jenkins provides no native provenance attestation mechanism — a platform limitation, recorded as such |
+
+The `DSB-SCAN-007` row is worth reading twice. The control is genuinely N/A, *and* the
+reason it is N/A is itself a defect elsewhere. Recording both is the point of the
+section.
+
+---
+
+## 7. Remediation, ordered by risk
+
+| # | Action | Rule | Severity |
+|---|---|---|---|
+| 1 | Replace static AWS keys with OIDC federation to a scoped IAM role | `DSB-ID-001` | **Critical** |
+| 2 | Remove `-DskipTests`; execute the test suite as a gate | `DSB-TEST-001` | **Critical** |
+| 3 | Remove `\|\| true` from the Snyk step; enforce or record a scoped, expiring exception | `DSB-EXC-001` | **Critical** |
+| 4 | Add container image scanning between build and push | `DSB-SCAN-005` | **High** |
+| 5 | Add secret scanning covering diff and full history | `DSB-SCAN-004` | **High** |
+| 6 | Bind credentials at stage scope, not pipeline scope | `DSB-ID-002` | **High** |
+| 7 | Retire one of the two SCA tools | `DSB-SCAN-010` | **High** |
+| 8 | Enforce the SonarQube quality gate | `DSB-SCAN-002` | **High** |
+| 9 | Replace mutable `:latest` with a commit-derived tag; deploy by digest | `DSB-DEPLOY-002` | **High** |
+| 10 | Add environment separation and an approval gate before production | `DSB-DEPLOY-003` | **High** |
+| 11 | Move deployment configuration into version control as manifests | `DSB-SRC-001` | Medium |
+| 12 | Add rollout verification after deploy | `DSB-DEPLOY-004` | Medium |
+| 13 | Add SBOM generation at build | `DSB-SC-001` | Medium |
+| 14 | Add DAST against pre-production only | `DSB-SCAN-009` | Medium |
+| 15 | Use ephemeral agents instead of `agent any` | `DSB-BUILD-004` | Medium |
+| 16 | Add Jenkinsfile scanning to the pipeline | `DSB-SCAN-008` | Medium |
+
+### A note on `:latest` (item 9)
+
+```groovy
+docker build -t ${REGISTRY}/myapp:latest .
+docker push ${REGISTRY}/myapp:latest
+kubectl set image deployment/myapp app=${REGISTRY}/myapp:latest
+```
+
+This violates three rules at once:
+
+- `DSB-BUILD-003` — no unique artifact identifier; every build overwrites the last
+- `DSB-ART-002` — the published tag is mutable
+- `DSB-DEPLOY-002` — Kubernetes resolves `:latest` at pull time, so the running image may
+  not be the one this pipeline built
+
+The consequence is that **no scan result can be attributed to a running workload**. Even
+after you add image scanning (item 4), `:latest` makes the result describe an artifact
+you cannot prove you are running. Item 9 is a prerequisite for item 4 being worth
+anything.
+
+---
+
+## 8. Rationale
+
+**Why the credential findings outrank the missing scanners.** A missing scanner means
+undetected risk. Static, pipeline-scoped AWS keys mean any compromised build dependency
+gets durable cloud access — the pipeline is not just failing to find risk, it is the
+delivery mechanism for it.
+
+**Why skipped tests rank equally.** This pipeline has never verified that the application
+works. That is a delivery failure before it is a security failure, and `DSB-TEST-002`
+exists precisely because scanners create the appearance that it has been covered.
+
+**Why `|| true` is called out as an exception rather than a bug.** It *is* a risk
+acceptance — just an invisible one, with no approver, no scope, and no expiry. Naming it
+under `DSB-EXC-001` puts it in front of someone who can decide whether to accept it,
+which is the entire purpose of the exception path.
+
+**Why the duplicate SCA is only High and not Critical.** It wastes time and triage
+capacity but does not create risk. It is ranked where it is because retiring one tool is
+cheap and immediately makes the pipeline faster — and a faster pipeline is one teams do
+not route around.
+
+---
+
+## 9. Curriculum pointers
+
+- Pipeline Security — credential scoping, agent isolation, and CI/CD as attack surface
+- Cloud Identity — replacing static keys with OIDC federation
+- Container Security — image scanning placement and immutable tagging
+- DevSecOps Foundations — why Test and Scan are separate phases
+- Risk Management — exceptions, and what distinguishes acceptance from suppression

--- a/devsecops-engineering-skill/references/applicability.md
+++ b/devsecops-engineering-skill/references/applicability.md
@@ -1,0 +1,161 @@
+# Applicability — The Control Selection Flow
+
+This is the five-step flow referenced by `SKILL.md` §5. Run it in order. Steps 2, 3, and
+4 can each end the evaluation for a rule; only rules that survive all three reach
+enforcement and placement.
+
+---
+
+## Step 1 — Workload inventory
+
+Establish what actually exists. Do not infer from the repository name or the team's
+description of itself — infer from what the build produces.
+
+| Question | Determines |
+|---|---|
+| Is there first-party source code, and in what languages? | `DSB-SCAN-002` |
+| Are third-party dependencies resolved? | `DSB-BUILD-002`, `DSB-SCAN-003`, `DSB-SC-001` |
+| Is a container image produced? | `DSB-SCAN-005` |
+| Is there infrastructure-as-code? | `DSB-SCAN-006`, `DSB-IAC-*` |
+| Are there Kubernetes manifests or charts? | `DSB-SCAN-007` |
+| Are pipeline definitions in the repository? | `DSB-SCAN-008` |
+| Is a network-reachable interface exposed? | `DSB-SCAN-009` |
+| Is an artifact published or promoted? | `DSB-ART-*`, `DSB-DEPLOY-002` |
+| Is there a deployable environment? | `DSB-DEPLOY-003`, `DSB-DEPLOY-004` |
+
+**Failure mode:** assuming a container scanner is needed because the org "uses
+Kubernetes". The question is whether *this pipeline* builds an image.
+
+---
+
+## Step 2 — Applicability test
+
+For each rule, read its `applicability` block:
+
+- `always: true` → the rule applies. Proceed to step 3.
+- `always: false` → the rule applies only if at least one `conditions` entry is true of
+  this workload and no `not_applicable_when` entry is true.
+
+If the rule does not apply, **stop** and record:
+
+```
+DSB-SCAN-005 — Not Applicable
+Reason: This workload publishes a Python package to an internal index.
+        No container image is produced.
+```
+
+That record is required by `DSB-EVD-003`. Omission is not an option.
+
+**Applicability is an engineering determination about the workload.** It is not a risk
+decision, not a budget decision, and not negotiable by preference. "We don't want to run
+SAST" is an exception (`DSB-EXC-001`), not a Not Applicable.
+
+---
+
+## Step 3 — Existing-capability check
+
+Before proposing any tool, ask what the organization already runs.
+
+```
+Required Capability:      <the capability the rule demands>
+Existing Organizational
+Tool:                     <the tool that already covers it>
+Decision:                 Use existing tool. Do not introduce a second.
+DSB Requirement:          <RULE-ID> — Satisfied
+```
+
+Every rule carries `tooling.prefer_existing_tool: true`. The `tooling.examples` list is
+**illustrative only** — naming a product there confers no DSB endorsement and creates no
+requirement to adopt it.
+
+A custom, proprietary, or internal tool satisfies a DSB rule exactly as well as a
+commercial one. The rule asks for a capability; it does not ask who wrote the scanner.
+
+Introducing a second tool for a capability already covered is a `DSB-SCAN-010` finding.
+
+---
+
+## Step 4 — Ownership-boundary check
+
+A control need not execute in the application pipeline when another governed
+organizational process legitimately owns and enforces it.
+
+Record it as:
+
+```
+DSB-SCAN-007 — Satisfied (externally owned)
+Owning process: Platform team's Kyverno admission policy on the shared EKS clusters.
+Enforcement:    Deployments violating baseline policy are rejected at admission.
+```
+
+Three conditions must all hold before you may use this outcome:
+
+1. The owning process is **named** — not "the platform team handles it".
+2. It is **enforced**, not merely available.
+3. It covers **this workload**, not a superset the workload might fall outside.
+
+If any of the three is unproven, it is a gap, not an external satisfaction. This is the
+determination most often claimed and least often verifiable — check it.
+
+---
+
+## Step 5 — Organizational context
+
+Apply the remaining factors to choose enforcement level and placement:
+
+| Factor | Typical effect |
+|---|---|
+| CI/CD platform | Available primitives, identity model, syntax |
+| Application architecture | Which test and scan surfaces are meaningful |
+| Language and package manager | SAST and SCA selection, pinning strategy |
+| Cloud and deployment platform | Federation, registry, admission control |
+| Registries in use | Immutability and signing capability |
+| Existing products and licences | Step 3 outcomes |
+| Existing governed processes | Step 4 outcomes |
+| Environment strategy | Whether `DSB-SCAN-009` has anywhere legal to run |
+| Responsibility separation | Platform vs. application ownership |
+| Risk tolerance | BLOCK vs. WARN on non-critical findings |
+| Compliance obligations | Added controls, longer evidence retention |
+
+---
+
+## Step 6 — Placement
+
+> Security controls execute at the **earliest technically valid stage where they produce
+> meaningful results**.
+
+"Earliest" is bounded by "meaningful". Both halves matter:
+
+- Secret scanning and SAST need only source → run them first, on the change itself.
+- SCA needs resolved dependencies → run it after resolution, not before.
+- Image scanning needs a built image → run it after build, before publication.
+- DAST needs a running system → run it after deployment to an authorized environment.
+
+Shifting a control earlier than its inputs exist does not make it faster; it makes it
+wrong. A container scan against a Dockerfile is not a container scan.
+
+See `references/capability-catalog.md` for the earliest-valid placement of every
+capability.
+
+---
+
+## Worked example
+
+**Workload:** Terraform module repository. No application code, no container, publishes
+to a private module registry, applied to AWS by a separate pipeline.
+
+| Rule | Outcome | Reason |
+|---|---|---|
+| `DSB-SCAN-001` | Applicable | Always applicable |
+| `DSB-SCAN-002` | **N/A** | No first-party application source code |
+| `DSB-SCAN-003` | Applicable | Provider and module dependencies are resolved |
+| `DSB-SCAN-004` | Applicable | Always applicable to source repositories |
+| `DSB-SCAN-005` | **N/A** | No container image produced |
+| `DSB-SCAN-006` | Applicable | The repository is entirely IaC |
+| `DSB-SCAN-007` | **N/A** | No Kubernetes resources |
+| `DSB-SCAN-008` | Applicable | Pipeline definitions are committed |
+| `DSB-SCAN-009` | **N/A** | Module repository exposes no runtime interface |
+| `DSB-IAC-002` | **Satisfied (externally owned)** | Plan review and gated apply are enforced by the platform team's environment pipeline, which is the only identity permitted to apply |
+| `DSB-TEST-001` | Applicable | Module has meaningful contract tests |
+
+Five of eleven controls do not execute here — and every one of them is written down.

--- a/devsecops-engineering-skill/references/capability-catalog.md
+++ b/devsecops-engineering-skill/references/capability-catalog.md
@@ -1,0 +1,135 @@
+# Security Capability Catalog
+
+Capabilities, not products. Each entry states the condition that makes the capability
+applicable, the earliest stage at which it produces meaningful results, and the DSB rule
+that owns it.
+
+Tool names throughout are **illustrative**. Naming a product confers no DSB endorsement
+and creates no requirement to adopt it. A custom, proprietary, or internal tool satisfies
+the capability identically (`tooling.prefer_existing_tool: true` on every rule).
+
+---
+
+## 1. Application and repository security
+
+| Capability | Applicable when | Earliest valid placement | Owning rule |
+|---|---|---|---|
+| **Static application security testing (SAST)** | First-party source code exists in a supported language | On the change, pre-merge — needs only source | `DSB-SCAN-002` |
+| **Software composition analysis (SCA)** | Any third-party dependency is resolved | After dependency resolution — needs the resolved graph | `DSB-SCAN-003` |
+| **Secret scanning** | A source repository exists (always) | On the change, pre-merge, plus full history | `DSB-SCAN-004` |
+| **Dependency / package integrity** | Dependencies resolve from an external source | During resolution, in Build | `DSB-BUILD-002` |
+| **License and compliance analysis** | Organizational policy or distribution model requires it | Alongside SCA | `DSB-SCAN-003` |
+
+*Illustrative:* Checkmarx, Semgrep, SonarQube, CodeQL, Fortify · Black Duck, Snyk,
+Dependabot, Trivy, OWASP Dependency-Check · Gitleaks, TruffleHog, platform-native secret
+scanning.
+
+**Placement note:** SCA before dependency resolution scans a manifest, not a dependency
+graph, and misses the transitive majority. This is the single most common placement
+error.
+
+---
+
+## 2. Infrastructure and platform security
+
+| Capability | Applicable when | Earliest valid placement | Owning rule |
+|---|---|---|---|
+| **IaC scanning** | The repository contains infrastructure-as-code | On the change, pre-merge — needs only the definitions | `DSB-SCAN-006` |
+| **Kubernetes / workload config scanning** | Kubernetes manifests, charts, or overlays exist | On the change; re-evaluate rendered output if templated | `DSB-SCAN-007` |
+| **Policy-as-code enforcement** | The organization maintains policy as code | Pre-merge on definitions, and at admission for defense in depth | `DSB-SCAN-007`, `DSB-IAC-002` |
+| **Plan / change-set review** | IaC applies to a shared or production environment | After plan generation, before apply | `DSB-IAC-002` |
+| **CI/CD pipeline configuration scanning** | Pipeline definitions live in the repository | On the change, pre-merge | `DSB-SCAN-008` |
+
+*Illustrative:* Checkov, tfsec, Terrascan, Trivy config, Prisma Cloud IaC · Kubescape,
+Datree · OPA/Gatekeeper, Kyverno, Sentinel · zizmor, octoscan.
+
+**Placement note:** for templated Kubernetes (Helm, Kustomize), scan the *rendered*
+output. Scanning the template alone misses everything values files introduce.
+
+---
+
+## 3. Artifact and supply chain security
+
+| Capability | Applicable when | Earliest valid placement | Owning rule |
+|---|---|---|---|
+| **Container / image scanning** | A container image is built or published | After image build, before publication | `DSB-SCAN-005` |
+| **SBOM generation** | A released artifact contains third-party components | At build, when the resolved set is known | `DSB-SC-001` |
+| **Third-party component pinning** | The pipeline consumes actions, plugins, modules, or base images | In the pipeline definition itself | `DSB-SC-002` |
+| **Artifact integrity verification** | Artifacts move between stages or systems | Before consumption or deployment | `DSB-DEPLOY-002`, `DSB-ART-002` |
+| **Artifact signing** | Policy or cross-boundary distribution requires it | At publication; verify before deploy | `DSB-ART-003` |
+| **Provenance / build attestation** | The platform supports generation | At build; verify before deploy | `DSB-SC-003` |
+
+*Illustrative:* Prisma Cloud, Trivy, Grype, Clair, registry-native scanning · Syft,
+cdxgen, CycloneDX and SPDX tooling · Sigstore Cosign, in-toto, Notary.
+
+**Placement note:** an SBOM generated after publication describes an artifact you have
+already shipped. Generate at build; attach at publication.
+
+---
+
+## 4. Dynamic and post-deployment security
+
+| Capability | Applicable when | Earliest valid placement | Owning rule |
+|---|---|---|---|
+| **DAST** | A network-reachable interface exists and a testable environment is available | After deployment to an authorized environment | `DSB-SCAN-009` |
+| **API security testing** | An API is exposed, ideally with a specification | After deployment to an authorized environment | `DSB-SCAN-009` |
+| **Post-deployment validation** | Any deployment to a testable environment occurs | Immediately after deploy | `DSB-DEPLOY-004` |
+| **Runtime validation** | Runtime behavior is in scope for the organization | Continuous, post-deployment | `DSB-SCAN-009` |
+
+*Illustrative:* OWASP ZAP, Burp Suite Enterprise, Invicti, StackHawk.
+
+> **Production authorization.** Active dynamic testing against production requires
+> explicit, documented organizational authorization. Without it, do not generate it and
+> do not recommend it. Active scanning is operationally indistinguishable from an attack
+> and can cause real outages and real data mutation.
+
+**Not a fifth phase.** These execute after Deploy but belong to Scan/verification.
+
+---
+
+## 5. Advanced and organization-dependent
+
+Incorporated when workload context, policy, or organizational requirements make them
+applicable. **Not baseline** — do not propose them by default, and do not treat their
+absence as a gap.
+
+| Capability | Consider when |
+|---|---|
+| **Fuzz testing** | The workload parses untrusted input at a boundary — protocols, file formats, deserialization |
+| **Interactive application security testing (IAST)** | Instrumented runtime is acceptable and a rich integration test suite already exists |
+| **Specialized compliance scanners** | A specific regime obliges it (payment, health, government) |
+| **Proprietary / internal tools** | The organization has built capability of its own — satisfies rules identically |
+| **Penetration testing workflows** | Policy, release cadence, or contract requires human-led assessment |
+
+---
+
+## Placement summary
+
+```
+PRE-MERGE (on the change)
+  ├─ Secret scanning                    DSB-SCAN-004   always
+  ├─ SAST                               DSB-SCAN-002   if first-party code
+  ├─ IaC scanning                       DSB-SCAN-006   if IaC
+  ├─ K8s / config scanning              DSB-SCAN-007   if K8s
+  └─ Pipeline config scanning           DSB-SCAN-008   if pipeline-as-code
+
+BUILD
+  ├─ Dependency integrity               DSB-BUILD-002  if dependencies
+  ├─ SCA (post-resolution)              DSB-SCAN-003   if dependencies
+  ├─ SBOM generation                    DSB-SC-001     if released artifact
+  └─ Provenance / attestation           DSB-SC-003     if platform supports
+
+POST-BUILD, PRE-PUBLISH
+  ├─ Container / image scanning         DSB-SCAN-005   if image built
+  └─ Artifact signing                   DSB-ART-003    if policy requires
+
+PRE-DEPLOY
+  ├─ Gate verification                  DSB-DEPLOY-001 always
+  ├─ Digest-pinned promotion            DSB-DEPLOY-002 if artifact promoted
+  └─ Signature / provenance verification DSB-ART-003   if signed
+
+POST-DEPLOY (authorized environment only)
+  ├─ Deployment verification            DSB-DEPLOY-004 if environment exists
+  ├─ DAST                               DSB-SCAN-009   if runtime interface
+  └─ API security testing               DSB-SCAN-009   if API exposed
+```

--- a/devsecops-engineering-skill/references/enforcement-model.md
+++ b/devsecops-engineering-skill/references/enforcement-model.md
@@ -1,0 +1,141 @@
+# Enforcement Model
+
+## The four outcomes
+
+| Outcome | Pipeline behavior | Use when |
+|---|---|---|
+| **BLOCK** | Cannot continue without satisfaction or an approved exception | The finding represents risk the organization has decided not to ship |
+| **WARN** | Surfaced to the team, pipeline continues | The signal is valuable but the false-positive rate or remediation cost does not justify stopping delivery |
+| **REPORT** | Evidence collected, no signal on the result | The output's value is trend, inventory, or audit rather than a per-run decision |
+| **N/A** | Control does not execute | The workload lacks the technology, artifact, or risk the control addresses |
+
+---
+
+## Applicability is not enforcement
+
+This distinction is the one most often collapsed, and collapsing it produces both of the
+common failures — pipelines carrying controls they do not need, and pipelines quietly
+dropping controls they do.
+
+| | Applicability | Enforcement |
+|---|---|---|
+| **Question** | Does this control make sense for this workload? | What happens when this control fails? |
+| **Driven by** | Engineering facts about the workload | Organizational risk policy |
+| **Decided by** | The engineer designing the pipeline | The organization |
+| **Negotiable?** | No — it is a factual determination | Yes — it is a policy position |
+| **Recorded as** | Applicable / N/A / Satisfied (externally owned) | BLOCK / WARN / REPORT |
+
+Two consequences follow:
+
+1. **You cannot make an applicable control disappear by lowering enforcement.** A
+   container scanner set to REPORT is still an applicable control; it is a control the
+   organization has chosen not to gate on. That is a legitimate, recorded decision — and
+   a different thing from N/A.
+2. **You cannot make an inapplicable control meaningful by raising enforcement.** A
+   BLOCK-level IaC scan on a repository with no IaC blocks nothing and teaches the team
+   that the gates are theatre.
+
+---
+
+## DSB defaults are recommendations
+
+Every rule's `enforcement.level` is the DSB default. The organization's policy may adjust
+it. When it does, say what is being traded:
+
+> DSB default for `DSB-SCAN-003` is BLOCK. You have set it to WARN for transitive
+> findings with no available fix. That is a defensible position given your patch cadence
+> — the trade is that a fix becoming available does not itself stop delivery, so you need
+> the review cadence in `DSB-EXC-002` to catch it.
+
+Never present a default as immovable, and never silently accept a downgrade without
+naming its cost.
+
+---
+
+## Choosing a level
+
+Escalate toward BLOCK as these become true:
+
+- The finding is **confirmed** rather than probabilistic
+- The finding is **reachable** in the deployed configuration
+- Remediation is **available** and proportionate
+- The control's false-positive rate is **low** in this codebase
+- The consequence of shipping it is **severe or irreversible**
+
+Descend toward WARN or REPORT as they become false. A high-noise BLOCK gate is not a
+strong control — it is a control the team will route around, and the routing becomes
+permanent.
+
+### Standard starting position
+
+| Class of finding | Default |
+|---|---|
+| Verified secret in source | BLOCK |
+| Critical/High vulnerability with an available fix | BLOCK |
+| Critical/High vulnerability with no available fix | WARN + tracked exception |
+| Medium/Low vulnerability | WARN |
+| Informational / inventory / SBOM | REPORT |
+| Insecure IaC that provisions public exposure | BLOCK |
+| Insecure IaC hardening recommendation | WARN |
+| Pipeline configuration weakness | WARN, escalating to BLOCK for credential exposure |
+
+---
+
+## Placement and enforcement interact
+
+The same control can carry different levels at different points:
+
+```
+Pull request         → SAST on changed code            WARN   (fast feedback)
+Merge to main        → SAST full scan                  BLOCK  (gate before build)
+Post-deploy to test  → DAST                            WARN   (noisy, slow)
+Promotion to prod    → Signature verification          BLOCK  (cheap, decisive)
+```
+
+This is deliberate. Feedback-stage controls optimize for speed and tolerance;
+gate-stage controls optimize for decisiveness.
+
+---
+
+## The exception path
+
+An exception is the **only** legitimate way past a BLOCK gate. It is governed by
+`DSB-EXC-001` and `DSB-EXC-002`.
+
+Every exception carries five fields. An exception missing any of them is invalid:
+
+| Field | Why it exists |
+|---|---|
+| **Rule** | Which requirement is being deviated from |
+| **Approver** | A named person or role accepting the risk — never "the team" |
+| **Scope** | The exact repository, workload, and finding — so it cannot widen silently |
+| **Justification** | Why remediation is not being done now |
+| **Expiry** | A fixed date — so "temporary" cannot become the architecture |
+
+### Anti-patterns
+
+| Pattern | Why it fails |
+|---|---|
+| Inline suppression comments with no expiry | Invisible to review, permanent by default |
+| `continue-on-error` on a BLOCK gate | An undocumented, unapproved, unlimited exception |
+| Removing the scanner instead of accepting the finding | Destroys the record that the risk was ever known |
+| Blanket exceptions across a whole repository | Unscoped — covers findings nobody has seen yet |
+| Auto-renewal on expiry | Defeats the only mechanism forcing reassessment |
+
+Suppressing a finding without an exception record is not risk acceptance. It is an
+unmanaged vulnerability with a paper trail pointing away from it.
+
+---
+
+## Reporting enforcement in output
+
+State the level, the placement, and the reason together:
+
+```
+DSB-SCAN-003  Software Composition Analysis
+  Tool:        Black Duck (existing organizational capability)
+  Placement:   After dependency resolution, before image build
+  Enforcement: BLOCK on Critical/High with an available fix
+               WARN on Critical/High with no fix, tracked under DSB-EXC-001
+  DSB default: BLOCK — retained
+```

--- a/devsecops-engineering-skill/references/framework-mappings.md
+++ b/devsecops-engineering-skill/references/framework-mappings.md
@@ -1,0 +1,142 @@
+# Framework Mappings
+
+DSB rules are cross-referenced against five authoritative external references. Each rule
+in `rules/*.yaml` carries a `framework_mappings` block with all five keys; an empty list
+means the rule has no meaningful correspondence in that framework, which is a legitimate
+and common outcome.
+
+```
+Industry Standards / Best Practices
+              ↓
+DSB DevSecOps Engineering Methodology
+              ↓
+DSB Rules
+              ↓
+Organizational Context
+              ↓
+Platform / Tool Implementation
+```
+
+**Frameworks inform the methodology. They do not replace engineering judgment and they
+do not dictate pipeline architecture.** A rule exists because it is sound engineering,
+not because a framework lists it — the mapping documents the correspondence, it does not
+justify the rule.
+
+**Compliance mapping is deferred by design.** Compliance regimes (SOC 2, PCI DSS,
+FedRAMP, HIPAA) are not the driver of this methodology and are not mapped in v0.1.0.
+Where an organization needs that traceability, the framework mappings below are the
+bridge — most regimes already map to NIST SSDF.
+
+---
+
+## The five references
+
+| Key | Reference | What it contributes |
+|---|---|---|
+| `nist_ssdf` | NIST SP 800-218, Secure Software Development Framework | Practice-level coverage across the whole lifecycle — the broadest mapping surface |
+| `slsa` | Supply-chain Levels for Software Artifacts | Build integrity and provenance, expressed as progressive levels |
+| `owasp_cicd` | OWASP Top 10 CI/CD Security Risks | The pipeline itself as attack surface |
+| `owasp_samm` | OWASP Software Assurance Maturity Model | Organizational maturity and process ownership |
+| `cncf_supply_chain` | CNCF Software Supply Chain Security guidance | Cloud-native supply chain, from source through deployment |
+
+---
+
+## NIST SSDF (SP 800-218)
+
+Referenced by practice identifier. The four groups:
+
+| Group | Meaning | DSB families drawing on it |
+|---|---|---|
+| **PO** — Prepare the Organization | People, process, and toolchain readiness | `DSB-ID`, `DSB-SRC`, `DSB-EXC`, `DSB-IAC` |
+| **PS** — Protect the Software | Integrity and protection of code and artifacts | `DSB-ART`, `DSB-SC`, `DSB-BUILD`, `DSB-DEPLOY` |
+| **PW** — Produce Well-Secured Software | Design, build, and verification practices | `DSB-BUILD`, `DSB-TEST`, `DSB-SCAN` |
+| **RV** — Respond to Vulnerabilities | Identification, remediation, and root cause | `DSB-SCAN`, `DSB-EVD`, `DSB-EXC` |
+
+SSDF is the widest mapping in the catalog because it is the only one of the five that
+covers organizational preparation, production, and response together.
+
+---
+
+## SLSA
+
+Referenced by track and level rather than by control ID.
+
+| Reference used | DSB correspondence |
+|---|---|
+| Build L1 — scripted build | `DSB-BUILD-001`, `DSB-SRC-001`, `DSB-IAC-001` |
+| Build L2 — hosted build platform, signed provenance | `DSB-BUILD-001`, `DSB-BUILD-004`, `DSB-ID-001`, `DSB-EVD-002` |
+| Build L3 — hardened, isolated builds, non-falsifiable provenance | `DSB-BUILD-004`, `DSB-ID-002`, `DSB-SC-002`, `DSB-SC-003` |
+| Provenance — available / authenticated / verified | `DSB-SC-003`, `DSB-ART-002`, `DSB-ART-003`, `DSB-DEPLOY-002` |
+
+DSB does not require a specific SLSA level. The mapping tells an organization which DSB
+rules move it up the track — the level target is theirs to set.
+
+---
+
+## OWASP Top 10 CI/CD Security Risks
+
+The only one of the five that treats the pipeline itself as the target.
+
+| Risk | DSB rules addressing it |
+|---|---|
+| CICD-SEC-1 Insufficient Flow Control Mechanisms | `DSB-DEPLOY-001`, `DSB-SRC-002`, `DSB-IAC-002`, `DSB-EXC-001`, `DSB-SCAN-001` |
+| CICD-SEC-2 Inadequate Identity and Access Management | `DSB-ID-001`, `DSB-ID-002`, `DSB-SRC-003`, `DSB-DEPLOY-003`, `DSB-SCAN-008` |
+| CICD-SEC-3 Dependency Chain Abuse | `DSB-BUILD-002`, `DSB-SCAN-003`, `DSB-SC-001`, `DSB-SC-002` |
+| CICD-SEC-4 Poisoned Pipeline Execution | `DSB-BUILD-001`, `DSB-BUILD-004`, `DSB-SC-002`, `DSB-SCAN-008` |
+| CICD-SEC-5 Insufficient PBAC | `DSB-ID-002`, `DSB-SRC-002`, `DSB-DEPLOY-003` |
+| CICD-SEC-6 Insufficient Credential Hygiene | `DSB-SCAN-004`, `DSB-ID-001`, `DSB-ID-003`, `DSB-SRC-003`, `DSB-IAC-003`, `DSB-EVD-002` |
+| CICD-SEC-7 Insecure System Configuration | `DSB-BUILD-004`, `DSB-SCAN-006`, `DSB-SCAN-007`, `DSB-SCAN-008`, `DSB-IAC-002`, `DSB-IAC-003` |
+| CICD-SEC-8 Ungoverned Usage of Third Party Services | `DSB-BUILD-002`, `DSB-SC-002`, `DSB-SCAN-010` |
+| CICD-SEC-9 Improper Artifact Integrity Validation | `DSB-BUILD-003`, `DSB-SCAN-005`, `DSB-SC-003`, `DSB-ART-001`, `DSB-ART-002`, `DSB-ART-003`, `DSB-DEPLOY-002` |
+| CICD-SEC-10 Insufficient Logging and Visibility | `DSB-EVD-001`, `DSB-EVD-002`, `DSB-EVD-003`, `DSB-ART-004`, `DSB-EXC-002` |
+
+Every one of the ten has at least one owning DSB rule. This is deliberate — Principle 16
+holds that the pipeline is production infrastructure and in scope for its own security.
+
+---
+
+## OWASP SAMM
+
+Mapped to business functions and security practices rather than specific activities,
+because SAMM describes organizational maturity rather than pipeline mechanics.
+
+| SAMM practice | DSB families |
+|---|---|
+| Governance — Strategy and Metrics | `DSB-SCAN-010`, `DSB-EVD-001` |
+| Governance — Policy and Compliance | `DSB-SRC-003`, `DSB-EVD-003`, `DSB-EXC-001`, `DSB-EXC-002` |
+| Implementation — Secure Build | `DSB-BUILD-*`, `DSB-SC-*`, `DSB-SRC-001`, `DSB-SRC-002` |
+| Implementation — Secure Deployment | `DSB-DEPLOY-*`, `DSB-ART-*`, `DSB-IAC-002` |
+| Verification — Requirements-driven Testing | `DSB-TEST-001`, `DSB-TEST-003` |
+| Verification — Security Testing | `DSB-SCAN-001`–`DSB-SCAN-009`, `DSB-TEST-002` |
+| Verification — Defect Management | `DSB-EXC-001`, `DSB-EXC-002` |
+| Operations — Environment Management | `DSB-BUILD-004`, `DSB-ID-*`, `DSB-SCAN-006`, `DSB-SCAN-007`, `DSB-IAC-*` |
+| Operations — Operational Management | `DSB-DEPLOY-003`, `DSB-DEPLOY-004`, `DSB-ART-004`, `DSB-EVD-001`, `DSB-EVD-002` |
+
+---
+
+## CNCF Software Supply Chain Security
+
+Mapped to the guidance's five stages.
+
+| Stage | DSB rules |
+|---|---|
+| Securing the Source Code | `DSB-SRC-001`, `DSB-SRC-002`, `DSB-SRC-003`, `DSB-SCAN-002`, `DSB-SCAN-004`, `DSB-SCAN-006` |
+| Securing Materials | `DSB-BUILD-002`, `DSB-SCAN-003`, `DSB-SC-001`, `DSB-SC-002` |
+| Securing Build Pipelines | `DSB-BUILD-001`, `DSB-BUILD-004`, `DSB-SCAN-001`, `DSB-SCAN-008`, `DSB-ID-*`, `DSB-SC-002`, `DSB-SC-003`, `DSB-EVD-001`, `DSB-EVD-002` |
+| Securing Artefacts | `DSB-BUILD-003`, `DSB-SCAN-005`, `DSB-SC-001`, `DSB-SC-003`, `DSB-ART-001`, `DSB-ART-002`, `DSB-ART-003`, `DSB-ART-004`, `DSB-DEPLOY-002` |
+| Securing Deployments | `DSB-DEPLOY-001`, `DSB-DEPLOY-003`, `DSB-DEPLOY-004`, `DSB-SCAN-007`, `DSB-SCAN-009`, `DSB-ART-003`, `DSB-IAC-001`, `DSB-IAC-002`, `DSB-IAC-003` |
+
+---
+
+## Using mappings in output
+
+Cite a mapping when it helps the reader connect DSB guidance to an obligation they
+already carry:
+
+> `DSB-SC-002` (pin third-party actions to commit SHAs) addresses **CICD-SEC-3
+> Dependency Chain Abuse** and **CICD-SEC-4 Poisoned Pipeline Execution**, and is a
+> prerequisite for **SLSA Build L3**.
+
+Do not lead with the framework. The engineering reason comes first; the mapping is
+supporting evidence for a reader who needs it. A recommendation whose only justification
+is "a framework says so" has failed Principle 20.

--- a/devsecops-engineering-skill/rules/artifacts.yaml
+++ b/devsecops-engineering-skill/rules/artifacts.yaml
@@ -1,0 +1,133 @@
+# DSB DevSecOps Engineering Rules — Artifacts
+# Where deliverables live, and what can be proven about them.
+family: DSB-ART
+scope: Artifacts, provenance, signing, and registries
+rules:
+  - id: DSB-ART-001
+    title: Artifacts are published to a governed registry or repository
+    phase: deploy
+    requirement: >-
+      Released artifacts are published to an artifact registry or repository under
+      organizational governance, with access control and retention. Ad hoc storage —
+      object-storage buckets, shared drives, pipeline job attachments used as the system
+      of record — is not an artifact repository.
+    rationale: >-
+      A governed registry is what gives artifacts access control, retention,
+      immutability, and a discovery path. Ad hoc storage provides none of these and
+      cannot support an incident investigation.
+    applicability:
+      always: false
+      conditions:
+        - The pipeline produces an artifact intended for reuse, promotion, or distribution
+      not_applicable_when:
+        - The build output is consumed only within the same pipeline run and is never promoted
+    framework_mappings:
+      nist_ssdf: [PS.1.1, PS.2.1, PS.3.1]
+      slsa: []
+      owasp_cicd: [CICD-SEC-9 Improper Artifact Integrity Validation]
+      owasp_samm: [Implementation — Secure Deployment]
+      cncf_supply_chain: [Securing Artefacts]
+    enforcement:
+      level: block
+      automatable: true
+    tooling:
+      examples:
+        - Artifact repositories (Artifactory, Nexus, cloud-native container and package registries)
+      prefer_existing_tool: true
+
+  - id: DSB-ART-002
+    title: Published artifacts are immutable
+    phase: deploy
+    requirement: >-
+      Once published, an artifact version or tag is never overwritten. Registries are
+      configured to prevent overwriting where the capability exists, and pipelines
+      publish a new version rather than replacing an existing one.
+    rationale: >-
+      If a tag can be overwritten, then every scan result, approval, and test record
+      attached to it describes something that may no longer exist. Immutability is the
+      precondition for trusting any artifact-level evidence.
+    applicability:
+      always: false
+      conditions:
+        - The pipeline publishes artifacts to a registry or repository
+      not_applicable_when:
+        - No artifact is published
+    framework_mappings:
+      nist_ssdf: [PS.2.1, PS.3.1]
+      slsa: [Provenance — available]
+      owasp_cicd: [CICD-SEC-9 Improper Artifact Integrity Validation]
+      owasp_samm: [Implementation — Secure Deployment]
+      cncf_supply_chain: [Securing Artefacts]
+    enforcement:
+      level: block
+      automatable: true
+    tooling:
+      examples:
+        - Registry immutable-tag settings and retention policies
+        - Digest-based references in place of mutable tags
+      prefer_existing_tool: true
+
+  - id: DSB-ART-003
+    title: Artifacts are signed and verified where policy or distribution model requires
+    phase: deploy
+    requirement: >-
+      Where the organization's policy, distribution model, or platform capability calls
+      for it, artifacts are cryptographically signed at publication and signatures are
+      verified before deployment or consumption.
+    rationale: >-
+      Signing without verification is a ceremony. The security property comes from the
+      deploying system refusing an artifact whose signature does not check out —
+      everything before that is preparation.
+    applicability:
+      always: false
+      conditions:
+        - Organizational policy requires artifact signing
+        - The artifact is distributed externally or consumed across trust boundaries
+      not_applicable_when:
+        - Artifacts remain within a single governed registry and policy does not require signing
+    framework_mappings:
+      nist_ssdf: [PS.2.1, PS.3.1, PW.6.2]
+      slsa: [Provenance — authenticated, Build L3 — non-falsifiable provenance]
+      owasp_cicd: [CICD-SEC-9 Improper Artifact Integrity Validation]
+      owasp_samm: [Implementation — Secure Deployment]
+      cncf_supply_chain: [Securing Artefacts, Securing Deployments]
+    enforcement:
+      level: warn
+      automatable: true
+    tooling:
+      examples:
+        - Sigstore Cosign, Notary, GPG signing
+        - Admission-time signature verification (Kyverno, Gatekeeper, registry policy)
+      prefer_existing_tool: true
+
+  - id: DSB-ART-004
+    title: Artifact, commit, build, and scan evidence are linked and retained
+    phase: cross-cutting
+    requirement: >-
+      For every released artifact it is possible to retrieve the commit it was built
+      from, the pipeline run that built it, and the test and scan results that gated it,
+      for as long as the artifact may be deployed.
+    rationale: >-
+      This chain is what an incident actually consumes. Retaining the artifact but not
+      its evidence, or the evidence past the retention of the artifact, breaks the chain
+      exactly when someone needs it.
+    applicability:
+      always: false
+      conditions:
+        - The pipeline releases artifacts
+      not_applicable_when:
+        - No artifact is released
+    framework_mappings:
+      nist_ssdf: [PS.3.1, PS.3.2, RV.1.2]
+      slsa: [Provenance — available]
+      owasp_cicd: [CICD-SEC-10 Insufficient Logging and Visibility]
+      owasp_samm: [Operations — Operational Management]
+      cncf_supply_chain: [Securing Artefacts]
+    enforcement:
+      level: report
+      automatable: true
+    tooling:
+      examples:
+        - Registry metadata, labels, and attached attestations
+        - Pipeline run records linked to artifact identifiers
+      prefer_existing_tool: true

--- a/devsecops-engineering-skill/rules/build.yaml
+++ b/devsecops-engineering-skill/rules/build.yaml
@@ -1,0 +1,132 @@
+# DSB DevSecOps Engineering Rules — Build
+# Phase: Build. Repeatable, traceable preparation of a deliverable.
+family: DSB-BUILD
+scope: Build and artifact creation
+rules:
+  - id: DSB-BUILD-001
+    title: Builds are automated and reproducible from source control
+    phase: build
+    requirement: >-
+      Every deliverable is produced by an automated build executed by the delivery
+      pipeline from a specific commit in version control. Builds performed manually, on
+      an engineer's workstation, or from uncommitted state must not produce artifacts
+      that reach a shared environment.
+    rationale: >-
+      A build that cannot be reproduced from a known commit cannot be reasoned about.
+      Every downstream control — testing, scanning, provenance, incident response —
+      depends on knowing exactly what source produced the artifact in question.
+    applicability:
+      always: true
+      conditions:
+        - A deliverable of any kind is produced
+      not_applicable_when: []
+    framework_mappings:
+      nist_ssdf: [PO.3.2, PS.1.1, PW.6.1]
+      slsa: [Build L1 — scripted build, Build L2 — hosted build platform]
+      owasp_cicd: [CICD-SEC-4 Poisoned Pipeline Execution]
+      owasp_samm: [Implementation — Secure Build]
+      cncf_supply_chain: [Securing Build Pipelines]
+    enforcement:
+      level: block
+      automatable: true
+    tooling:
+      examples:
+        - Any CI/CD platform (GitHub Actions, Jenkins, GitLab CI, Azure DevOps, Tekton)
+        - Any build tool native to the project (Maven, Gradle, npm, Go, Cargo, Make)
+      prefer_existing_tool: true
+
+  - id: DSB-BUILD-002
+    title: Dependencies resolve from governed sources with pinned, integrity-verified versions
+    phase: build
+    requirement: >-
+      Third-party dependencies are resolved from an approved registry, mirror, or proxy;
+      versions are pinned via a committed lockfile or equivalent; and integrity is
+      verified (checksum, hash, or signature) during resolution.
+    rationale: >-
+      Floating versions make the build non-deterministic and hand an attacker a mutable
+      input. Pinning plus integrity verification is what makes dependency-chain abuse
+      detectable rather than silent.
+    applicability:
+      always: false
+      conditions:
+        - The build resolves any third-party dependency
+      not_applicable_when:
+        - The deliverable has no external dependencies (rare — verify before claiming)
+    framework_mappings:
+      nist_ssdf: [PW.4.1, PW.4.4, PO.3.1]
+      slsa: [Build L2 — provenance of build inputs]
+      owasp_cicd: [CICD-SEC-3 Dependency Chain Abuse, CICD-SEC-8 Ungoverned Usage of Third Party Services]
+      owasp_samm: [Implementation — Secure Build]
+      cncf_supply_chain: [Securing Materials]
+    enforcement:
+      level: block
+      automatable: true
+    tooling:
+      examples:
+        - Artifact repository / proxy (Artifactory, Nexus, cloud-native artifact registries)
+        - Native lockfiles (package-lock.json, poetry.lock, go.sum, Gemfile.lock, .terraform.lock.hcl)
+      prefer_existing_tool: true
+
+  - id: DSB-BUILD-003
+    title: Every build produces a uniquely identified artifact traceable to its commit
+    phase: build
+    requirement: >-
+      Each build emits an artifact with a unique, immutable identifier (digest, version,
+      or build ID) that is recorded together with the source commit, the build
+      execution, and the pipeline run that produced it.
+    rationale: >-
+      Traceability from a running deployment back to a commit is the precondition for
+      answering "is this affected?" during an incident. Without it, every downstream
+      evidence claim is unanchored.
+    applicability:
+      always: true
+      conditions:
+        - A deliverable of any kind is produced
+      not_applicable_when: []
+    framework_mappings:
+      nist_ssdf: [PS.3.1, PS.3.2, PW.6.2]
+      slsa: [Provenance — available]
+      owasp_cicd: [CICD-SEC-9 Improper Artifact Integrity Validation]
+      owasp_samm: [Implementation — Secure Build]
+      cncf_supply_chain: [Securing Artefacts]
+    enforcement:
+      level: block
+      automatable: true
+    tooling:
+      examples:
+        - Container image digests
+        - Registry-assigned immutable version identifiers
+        - Build metadata emitted by the CI/CD platform
+      prefer_existing_tool: true
+
+  - id: DSB-BUILD-004
+    title: Build environments are ephemeral, isolated, and least-privileged
+    phase: build
+    requirement: >-
+      Builds execute in an environment that is created for the run and discarded after
+      it, isolated from other builds, and granted only the permissions the build itself
+      requires. Build jobs must not hold deployment or production credentials.
+    rationale: >-
+      A persistent, shared, over-privileged build host is the highest-value target in
+      the delivery chain — it can reach source, artifacts, and production at once.
+      Ephemerality removes the persistence an attacker needs.
+    applicability:
+      always: true
+      conditions:
+        - Any build executes on shared or hosted infrastructure
+      not_applicable_when: []
+    framework_mappings:
+      nist_ssdf: [PO.5.1, PO.5.2, PO.3.3]
+      slsa: [Build L2 — hosted build platform, Build L3 — isolated builds]
+      owasp_cicd: [CICD-SEC-4 Poisoned Pipeline Execution, CICD-SEC-7 Insecure System Configuration]
+      owasp_samm: [Operations — Environment Management]
+      cncf_supply_chain: [Securing Build Pipelines]
+    enforcement:
+      level: warn
+      automatable: false
+    tooling:
+      examples:
+        - Ephemeral hosted runners or agents
+        - Container-per-job or VM-per-job execution models
+        - Job-scoped credential issuance
+      prefer_existing_tool: true

--- a/devsecops-engineering-skill/rules/deploy.yaml
+++ b/devsecops-engineering-skill/rules/deploy.yaml
@@ -1,0 +1,132 @@
+# DSB DevSecOps Engineering Rules — Deploy
+# Phase: Deploy. Deliver or promote only what passed.
+family: DSB-DEPLOY
+scope: Deployment and promotion
+rules:
+  - id: DSB-DEPLOY-001
+    title: Only artifacts that passed every applicable gate may be deployed or promoted
+    phase: deploy
+    requirement: >-
+      Deployment, publication, and promotion are conditional on successful completion of
+      every applicable Build, Test, and Scan requirement, or on an approved exception
+      recorded under DSB-EXC-001.
+    rationale: >-
+      A gate that does not stop delivery is a report, not a gate. This rule is what makes
+      the preceding three phases mean anything operationally.
+    applicability:
+      always: true
+      conditions:
+        - The pipeline deploys, publishes, or promotes anything
+      not_applicable_when: []
+    framework_mappings:
+      nist_ssdf: [PS.1.1, PW.8.2, RV.1.1]
+      slsa: [Build L2 — provenance verified before use]
+      owasp_cicd: [CICD-SEC-1 Insufficient Flow Control Mechanisms]
+      owasp_samm: [Implementation — Secure Deployment]
+      cncf_supply_chain: [Securing Deployments]
+    enforcement:
+      level: block
+      automatable: true
+    tooling:
+      examples:
+        - Native pipeline job dependencies and required status checks
+        - Environment protection rules and deployment gates
+      prefer_existing_tool: true
+
+  - id: DSB-DEPLOY-002
+    title: Deploy the exact artifact that was tested and scanned
+    phase: deploy
+    requirement: >-
+      Promotion references the immutable identifier (digest or equivalent) of the
+      artifact that passed the gates. Rebuilding from source at deploy time, or
+      resolving a mutable tag such as `latest`, is prohibited.
+    rationale: >-
+      A rebuild is a different artifact with different dependency resolution, and every
+      scan result you hold describes the artifact you did not ship. Mutable tags make
+      this failure silent.
+    applicability:
+      always: false
+      conditions:
+        - An artifact is produced in one stage and deployed or promoted in another
+      not_applicable_when:
+        - The pipeline builds and deploys in a single indivisible step with no
+          intermediate artifact
+    framework_mappings:
+      nist_ssdf: [PS.2.1, PS.3.1, PW.6.2]
+      slsa: [Provenance — verified, Build L3 — non-falsifiable provenance]
+      owasp_cicd: [CICD-SEC-9 Improper Artifact Integrity Validation]
+      owasp_samm: [Implementation — Secure Deployment]
+      cncf_supply_chain: [Securing Artefacts, Securing Deployments]
+    enforcement:
+      level: block
+      automatable: true
+    tooling:
+      examples:
+        - Digest-pinned image references
+        - Immutable registry versions and promotion-by-reference workflows
+      prefer_existing_tool: true
+
+  - id: DSB-DEPLOY-003
+    title: Deployments are automated, authorized, and traceable
+    phase: deploy
+    requirement: >-
+      Deployments to shared and production environments execute through the pipeline
+      under an authorization model appropriate to the environment, and record who or
+      what authorized the deployment, which artifact was deployed, and which commit it
+      came from.
+    rationale: >-
+      Manual, out-of-band deployment defeats every control in the chain simultaneously.
+      Recorded authorization is what makes a deployment reviewable after the fact rather
+      than merely observed.
+    applicability:
+      always: false
+      conditions:
+        - The workload deploys to a shared or production environment
+      not_applicable_when:
+        - The pipeline publishes to a registry only and performs no environment deployment
+    framework_mappings:
+      nist_ssdf: [PO.3.2, PS.3.1, PO.5.1]
+      slsa: []
+      owasp_cicd: [CICD-SEC-2 Inadequate Identity and Access Management, CICD-SEC-5 Insufficient PBAC]
+      owasp_samm: [Implementation — Secure Deployment, Operations — Operational Management]
+      cncf_supply_chain: [Securing Deployments]
+    enforcement:
+      level: block
+      automatable: true
+    tooling:
+      examples:
+        - Environment approval gates and protected environments
+        - GitOps controllers with recorded reconciliation
+      prefer_existing_tool: true
+
+  - id: DSB-DEPLOY-004
+    title: Post-deployment verification executes against the deployed environment
+    phase: deploy
+    requirement: >-
+      After deployment to a testable environment, the pipeline verifies that the
+      deployment succeeded and triggers any runtime-dependent security validation that
+      applies under DSB-SCAN-009.
+    rationale: >-
+      Deployment succeeding is not the same as the system working, and a class of
+      security defect is only observable at runtime. This is the hand-off point between
+      the Deploy phase and runtime-dependent scanning.
+    applicability:
+      always: false
+      conditions:
+        - The workload is deployed to an environment that can be exercised after deployment
+      not_applicable_when:
+        - The pipeline publishes an artifact only, with no environment to verify
+    framework_mappings:
+      nist_ssdf: [RV.1.1, PW.8.2]
+      slsa: []
+      owasp_cicd: []
+      owasp_samm: [Operations — Operational Management, Verification — Security Testing]
+      cncf_supply_chain: [Securing Deployments]
+    enforcement:
+      level: warn
+      automatable: true
+    tooling:
+      examples:
+        - Smoke and health-check jobs
+        - Post-deployment DAST or API security testing triggers
+      prefer_existing_tool: true

--- a/devsecops-engineering-skill/rules/evidence.yaml
+++ b/devsecops-engineering-skill/rules/evidence.yaml
@@ -1,0 +1,97 @@
+# DSB DevSecOps Engineering Rules — Evidence
+# A control that leaves no record cannot be assessed, audited, or improved.
+family: DSB-EVD
+scope: Evidence, logging, and observability
+rules:
+  - id: DSB-EVD-001
+    title: Every gate produces retained, machine-readable evidence
+    phase: cross-cutting
+    requirement: >-
+      Test and scan gates emit results in a machine-readable format, retained for a
+      period the organization defines and at least as long as the artifact they gated
+      may be deployed.
+    rationale: >-
+      Human-readable console output is not evidence — it cannot be queried, trended, or
+      produced on request months later. Machine-readable results are also what let you
+      answer whether a control was passing before a regression.
+    applicability:
+      always: true
+      conditions:
+        - Any test or scan gate exists
+      not_applicable_when: []
+    framework_mappings:
+      nist_ssdf: [PS.3.2, PW.8.2, RV.1.2]
+      slsa: [Provenance — available]
+      owasp_cicd: [CICD-SEC-10 Insufficient Logging and Visibility]
+      owasp_samm: [Governance — Strategy and Metrics, Operations — Operational Management]
+      cncf_supply_chain: [Securing Build Pipelines]
+    enforcement:
+      level: report
+      automatable: true
+    tooling:
+      examples:
+        - SARIF, JUnit XML, SPDX, CycloneDX outputs
+        - Platform-native results ingestion and artifact retention
+      prefer_existing_tool: true
+
+  - id: DSB-EVD-002
+    title: Pipeline execution is logged, auditable, and free of secret material
+    phase: cross-cutting
+    requirement: >-
+      Pipeline runs record what executed, on which commit, under which identity, and
+      with what result. Logs are retained per policy and must not contain secrets,
+      tokens, or credential material.
+    rationale: >-
+      Pipeline logs are the primary forensic record for a supply-chain incident. They
+      are also read far more widely than teams expect, which is why a leaked token in a
+      log is a live credential, not a historical one.
+    applicability:
+      always: true
+      conditions:
+        - Any pipeline executes
+      not_applicable_when: []
+    framework_mappings:
+      nist_ssdf: [PO.3.3, PS.3.1, RV.1.1]
+      slsa: [Build L2 — hosted build platform]
+      owasp_cicd: [CICD-SEC-10 Insufficient Logging and Visibility, CICD-SEC-6 Insufficient Credential Hygiene]
+      owasp_samm: [Operations — Operational Management]
+      cncf_supply_chain: [Securing Build Pipelines]
+    enforcement:
+      level: warn
+      automatable: true
+    tooling:
+      examples:
+        - Platform-native run history with log masking
+        - Log forwarding to the organization's SIEM
+      prefer_existing_tool: true
+
+  - id: DSB-EVD-003
+    title: Not Applicable determinations are explicitly recorded with justification
+    phase: cross-cutting
+    requirement: >-
+      Every control excluded from a pipeline is recorded as Not Applicable together with
+      the workload fact that makes it inapplicable. A control may never be omitted
+      silently.
+    rationale: >-
+      Silence is indistinguishable from oversight. An explicit N/A with a reason is
+      reviewable — someone can disagree with it — and it automatically becomes wrong
+      when the workload changes, which is exactly the signal you want.
+    applicability:
+      always: true
+      conditions:
+        - Any control is excluded from a pipeline
+      not_applicable_when: []
+    framework_mappings:
+      nist_ssdf: [PO.1.3, PO.3.1, RV.2.2]
+      slsa: []
+      owasp_cicd: [CICD-SEC-10 Insufficient Logging and Visibility]
+      owasp_samm: [Governance — Policy and Compliance]
+      cncf_supply_chain: []
+    enforcement:
+      level: block
+      automatable: false
+    tooling:
+      examples:
+        - A committed applicability record in the repository
+        - The Not Applicable section required by the skill's output contract
+      prefer_existing_tool: true

--- a/devsecops-engineering-skill/rules/exceptions.yaml
+++ b/devsecops-engineering-skill/rules/exceptions.yaml
@@ -1,0 +1,69 @@
+# DSB DevSecOps Engineering Rules — Exceptions
+# The only legitimate way past a BLOCK gate.
+family: DSB-EXC
+scope: Exceptions and risk acceptance
+rules:
+  - id: DSB-EXC-001
+    title: Exceptions require a named approver, documented scope, and an expiry date
+    phase: cross-cutting
+    requirement: >-
+      Any deviation from an applicable DSB requirement is recorded as an exception
+      carrying: the rule deviated from, the named individual or role accepting the risk,
+      the precise scope (which repository, workload, and finding), the justification,
+      and a fixed expiry date. Exceptions without all five are invalid.
+    rationale: >-
+      Every one of the five fields exists to prevent a specific failure. No name means
+      nobody owns the risk; no scope means it silently widens; no expiry means it is
+      permanent. An undocumented bypass is simply an unmanaged vulnerability.
+    applicability:
+      always: false
+      conditions:
+        - A deviation from an applicable requirement is proposed or in place
+      not_applicable_when:
+        - No deviations exist
+    framework_mappings:
+      nist_ssdf: [PO.1.3, RV.2.2, RV.3.3]
+      slsa: []
+      owasp_cicd: [CICD-SEC-1 Insufficient Flow Control Mechanisms]
+      owasp_samm: [Governance — Policy and Compliance, Verification — Defect Management]
+      cncf_supply_chain: []
+    enforcement:
+      level: block
+      automatable: false
+    tooling:
+      examples:
+        - The organization's risk register or GRC platform
+        - A committed, reviewed exceptions file in the repository
+      prefer_existing_tool: true
+
+  - id: DSB-EXC-002
+    title: Exceptions are tracked, reviewed at expiry, and never silently renewed
+    phase: cross-cutting
+    requirement: >-
+      Active exceptions are visible in one place, reviewed on or before expiry, and
+      either remediated or explicitly re-approved through the same process that created
+      them. Expiry must not pass unnoticed, and renewal must not be automatic.
+    rationale: >-
+      Exceptions are where accepted risk accumulates invisibly. Without a review at
+      expiry, "temporary" becomes the architecture, and the organization loses any
+      accurate picture of what it has actually accepted.
+    applicability:
+      always: false
+      conditions:
+        - Any exception has been granted
+      not_applicable_when:
+        - No exceptions exist
+    framework_mappings:
+      nist_ssdf: [RV.2.2, RV.3.3, PO.1.3]
+      slsa: []
+      owasp_cicd: [CICD-SEC-10 Insufficient Logging and Visibility]
+      owasp_samm: [Verification — Defect Management, Governance — Policy and Compliance]
+      cncf_supply_chain: []
+    enforcement:
+      level: warn
+      automatable: true
+    tooling:
+      examples:
+        - Expiry alerting from the risk register or ticketing system
+        - Scheduled pipeline job failing builds whose exceptions have lapsed
+      prefer_existing_tool: true

--- a/devsecops-engineering-skill/rules/iac.yaml
+++ b/devsecops-engineering-skill/rules/iac.yaml
@@ -1,0 +1,101 @@
+# DSB DevSecOps Engineering Rules — Infrastructure as Code
+# Infrastructure is a deliverable and follows the same four phases.
+family: DSB-IAC
+scope: Infrastructure-as-code security
+rules:
+  - id: DSB-IAC-001
+    title: Infrastructure changes are delivered through the same four-phase pipeline
+    phase: cross-cutting
+    requirement: >-
+      Infrastructure-as-code follows Build → Test → Scan → Deploy like any other
+      deliverable: validated and formatted (Build), exercised where meaningful test
+      surface exists (Test), scanned for insecure configuration (Scan), and applied only
+      after passing (Deploy).
+    rationale: >-
+      Infrastructure is the most privileged deliverable in the organization and is
+      routinely the least gated. Treating it as a special case is how a
+      network-exposing change ships with less scrutiny than a UI copy change.
+    applicability:
+      always: false
+      conditions:
+        - The repository contains infrastructure-as-code
+      not_applicable_when:
+        - The workload declares no infrastructure
+    framework_mappings:
+      nist_ssdf: [PO.3.2, PW.7.1, PO.5.1]
+      slsa: [Build L1 — scripted build]
+      owasp_cicd: [CICD-SEC-7 Insecure System Configuration]
+      owasp_samm: [Operations — Environment Management]
+      cncf_supply_chain: [Securing Deployments]
+    enforcement:
+      level: block
+      automatable: true
+    tooling:
+      examples:
+        - Native validate and format commands (terraform validate/fmt, cfn-lint, ansible-lint)
+        - The organization's existing CI/CD platform
+      prefer_existing_tool: true
+
+  - id: DSB-IAC-002
+    title: A change preview is produced and reviewed before infrastructure is applied
+    phase: deploy
+    requirement: >-
+      A plan, change set, or equivalent preview of the intended infrastructure change is
+      generated and made reviewable before apply. Apply to shared or production
+      environments is gated on that review and on the applicable scan results.
+    rationale: >-
+      IaC diffs routinely hide destructive changes — a resource replacement that reads
+      as a one-line attribute edit. The plan is the only artifact that shows what will
+      actually happen.
+    applicability:
+      always: false
+      conditions:
+        - Infrastructure-as-code is applied to a shared or production environment
+        - The IaC tool supports plan or change-set generation
+      not_applicable_when:
+        - Infrastructure changes apply only to ephemeral, self-owned development environments
+    framework_mappings:
+      nist_ssdf: [PO.3.2, PW.7.1, PS.3.1]
+      slsa: []
+      owasp_cicd: [CICD-SEC-1 Insufficient Flow Control Mechanisms, CICD-SEC-7 Insecure System Configuration]
+      owasp_samm: [Operations — Environment Management, Implementation — Secure Deployment]
+      cncf_supply_chain: [Securing Deployments]
+    enforcement:
+      level: block
+      automatable: true
+    tooling:
+      examples:
+        - terraform plan / CloudFormation change sets / pulumi preview posted to the change request
+        - Policy-as-code evaluation of the plan output (OPA, Sentinel, Checkov plan mode)
+      prefer_existing_tool: true
+
+  - id: DSB-IAC-003
+    title: Infrastructure state and backends are access-controlled, encrypted, and locked
+    phase: cross-cutting
+    requirement: >-
+      IaC state is stored in a remote backend with access control, encryption at rest,
+      and concurrency locking. State must not be committed to version control, and
+      access to it is limited to the pipeline identities and humans that require it.
+    rationale: >-
+      State files commonly contain secrets and always contain a complete map of the
+      environment. Unlocked state additionally allows two concurrent applies to corrupt
+      the environment outright.
+    applicability:
+      always: false
+      conditions:
+        - The IaC tool maintains state
+      not_applicable_when:
+        - The IaC tool is stateless (for example, agentless configuration management)
+    framework_mappings:
+      nist_ssdf: [PO.5.1, PO.5.2, PS.1.1]
+      slsa: []
+      owasp_cicd: [CICD-SEC-6 Insufficient Credential Hygiene, CICD-SEC-7 Insecure System Configuration]
+      owasp_samm: [Operations — Environment Management]
+      cncf_supply_chain: [Securing Deployments]
+    enforcement:
+      level: block
+      automatable: false
+    tooling:
+      examples:
+        - Remote state backends with encryption and locking (S3 + DynamoDB, Terraform Cloud, GCS, Azure Storage)
+      prefer_existing_tool: true

--- a/devsecops-engineering-skill/rules/identity.yaml
+++ b/devsecops-engineering-skill/rules/identity.yaml
@@ -1,0 +1,103 @@
+# DSB DevSecOps Engineering Rules — Identity
+# Cross-cutting: how the pipeline itself authenticates and what it is allowed to reach.
+family: DSB-ID
+scope: Workload identity, authentication, and authorization
+rules:
+  - id: DSB-ID-001
+    title: Pipelines authenticate with short-lived federated workload identity
+    phase: cross-cutting
+    requirement: >-
+      Pipeline authentication to cloud providers, registries, and other external systems
+      uses short-lived credentials issued to a federated workload identity (OIDC or
+      equivalent). Long-lived static credentials stored as pipeline secrets must be
+      replaced wherever the target platform supports federation.
+    rationale: >-
+      A static cloud key in CI is a permanent, exfiltratable credential that survives
+      every rotation policy nobody runs. Federated identity makes the credential
+      worthless minutes after the job ends, and ties every action to a specific pipeline
+      run.
+    applicability:
+      always: false
+      conditions:
+        - The pipeline authenticates to any external system
+      not_applicable_when:
+        - The target platform genuinely offers no federation mechanism — record the gap
+          and the compensating controls, do not mark satisfied
+    framework_mappings:
+      nist_ssdf: [PO.5.1, PO.5.2, PO.3.3]
+      slsa: [Build L2 — hosted build platform]
+      owasp_cicd: [CICD-SEC-2 Inadequate Identity and Access Management, CICD-SEC-6 Insufficient Credential Hygiene]
+      owasp_samm: [Operations — Environment Management]
+      cncf_supply_chain: [Securing Build Pipelines]
+    enforcement:
+      level: block
+      automatable: true
+    tooling:
+      examples:
+        - OIDC federation to cloud IAM roles
+        - Workload identity federation and short-lived registry tokens
+        - Any organizational secrets platform issuing dynamic credentials
+      prefer_existing_tool: true
+
+  - id: DSB-ID-002
+    title: Pipeline permissions are least-privilege and scoped per job and environment
+    phase: cross-cutting
+    requirement: >-
+      Pipeline tokens and roles grant only the permissions each job requires. Default
+      broad-write tokens are narrowed explicitly, and permissions that reach production
+      are scoped to the jobs that deploy to production.
+    rationale: >-
+      A build job holding deployment rights turns any dependency compromise into a
+      production compromise. Per-job scoping is what keeps a poisoned build contained to
+      the build.
+    applicability:
+      always: true
+      conditions:
+        - Any pipeline holds credentials or platform permissions
+      not_applicable_when: []
+    framework_mappings:
+      nist_ssdf: [PO.5.1, PO.5.2]
+      slsa: [Build L3 — isolated builds]
+      owasp_cicd: [CICD-SEC-2 Inadequate Identity and Access Management, CICD-SEC-5 Insufficient PBAC]
+      owasp_samm: [Operations — Environment Management]
+      cncf_supply_chain: [Securing Build Pipelines]
+    enforcement:
+      level: block
+      automatable: true
+    tooling:
+      examples:
+        - Job-level permission declarations
+        - Environment-scoped credentials and deployment roles
+      prefer_existing_tool: true
+
+  - id: DSB-ID-003
+    title: Secrets are injected at runtime from a managed store and never persisted
+    phase: cross-cutting
+    requirement: >-
+      Secrets required by the pipeline are retrieved at execution time from a managed
+      secret store or the platform's secret mechanism, are never written to source
+      control, artifacts, or logs, and are masked in pipeline output.
+    rationale: >-
+      Every secret that touches disk, an artifact layer, or a log line becomes a secret
+      you no longer control the lifetime of. Build logs in particular are widely
+      readable and retained far longer than anyone assumes.
+    applicability:
+      always: false
+      conditions:
+        - The pipeline consumes any secret
+      not_applicable_when:
+        - The pipeline requires no secrets at all
+    framework_mappings:
+      nist_ssdf: [PO.5.2, PS.1.1]
+      slsa: []
+      owasp_cicd: [CICD-SEC-6 Insufficient Credential Hygiene]
+      owasp_samm: [Operations — Environment Management]
+      cncf_supply_chain: [Securing Build Pipelines]
+    enforcement:
+      level: block
+      automatable: true
+    tooling:
+      examples:
+        - Managed secret stores (HashiCorp Vault, cloud secret managers, CyberArk)
+        - Platform-native encrypted secrets with log masking
+      prefer_existing_tool: true

--- a/devsecops-engineering-skill/rules/scan.yaml
+++ b/devsecops-engineering-skill/rules/scan.yaml
@@ -1,0 +1,318 @@
+# DSB DevSecOps Engineering Rules — Scan
+# Phase: Scan. Non-negotiable as a phase; individual scanners are conditional
+# on the technology, artifact, or risk actually present in the workload.
+family: DSB-SCAN
+scope: Security scanning and validation
+rules:
+  - id: DSB-SCAN-001
+    title: Every delivery pipeline includes security scanning appropriate to the workload
+    phase: scan
+    requirement: >-
+      No pipeline delivers to a shared environment without a Scan phase. The specific
+      scanners are determined by applicability, but the presence of the phase itself is
+      not optional and not subject to workload conditions.
+    rationale: >-
+      This is the rule that makes the methodology DevSecOps rather than DevOps. Every
+      other scan rule is conditional; this one is the floor.
+    applicability:
+      always: true
+      conditions:
+        - Any delivery pipeline exists
+      not_applicable_when: []
+    framework_mappings:
+      nist_ssdf: [PW.7.1, PW.8.2, RV.1.1]
+      slsa: []
+      owasp_cicd: [CICD-SEC-1 Insufficient Flow Control Mechanisms]
+      owasp_samm: [Verification — Security Testing]
+      cncf_supply_chain: [Securing Build Pipelines]
+    enforcement:
+      level: block
+      automatable: true
+    tooling:
+      examples: []
+      prefer_existing_tool: true
+
+  - id: DSB-SCAN-002
+    title: Static application security testing where first-party source code exists
+    phase: scan
+    requirement: >-
+      Repositories containing first-party application source code are subject to static
+      analysis for security defects, covering the languages actually present.
+    rationale: >-
+      SAST finds classes of defect that no dependency scanner can see, because the
+      vulnerable code is yours. It is also the earliest technically valid point at which
+      those defects can be caught.
+    applicability:
+      always: false
+      conditions:
+        - The repository contains first-party application source code in a language the
+          organization's SAST capability supports
+      not_applicable_when:
+        - The repository contains only configuration, IaC, documentation, or content
+        - The repository only vendors third-party code it does not modify
+    framework_mappings:
+      nist_ssdf: [PW.7.1, PW.7.2, PW.8.2]
+      slsa: []
+      owasp_cicd: []
+      owasp_samm: [Verification — Security Testing]
+      cncf_supply_chain: [Securing the Source Code]
+    enforcement:
+      level: block
+      automatable: true
+    tooling:
+      examples:
+        - Any organizational SAST capability (Checkmarx, Semgrep, SonarQube, CodeQL, Fortify)
+        - Internal or proprietary static analysis platforms
+      prefer_existing_tool: true
+
+  - id: DSB-SCAN-003
+    title: Software composition analysis where third-party dependencies exist
+    phase: scan
+    requirement: >-
+      Workloads that consume third-party dependencies are scanned for known
+      vulnerabilities in those dependencies, including transitive ones.
+    rationale: >-
+      Most exploitable risk in a modern application arrives through dependencies the
+      team never explicitly chose. Transitive coverage is the requirement — direct-only
+      scanning misses the majority of the graph.
+    applicability:
+      always: false
+      conditions:
+        - The workload resolves any third-party dependency, package, module, or library
+      not_applicable_when:
+        - The workload has no external dependencies
+    framework_mappings:
+      nist_ssdf: [PW.4.1, PW.4.4, RV.1.1, RV.1.2]
+      slsa: []
+      owasp_cicd: [CICD-SEC-3 Dependency Chain Abuse]
+      owasp_samm: [Verification — Security Testing, Implementation — Secure Build]
+      cncf_supply_chain: [Securing Materials]
+    enforcement:
+      level: block
+      automatable: true
+    tooling:
+      examples:
+        - Any organizational SCA capability (Black Duck, Snyk, Dependabot, Trivy, OWASP Dependency-Check)
+      prefer_existing_tool: true
+
+  - id: DSB-SCAN-004
+    title: Secret scanning on all source repositories
+    phase: scan
+    requirement: >-
+      Every repository in scope is scanned for committed credentials, tokens, keys, and
+      other secrets, covering both incoming changes and existing history.
+    rationale: >-
+      A committed secret is exploitable from the moment it lands and is not remediated
+      by deleting the line. This applies to every repository regardless of what it
+      builds, which is why it carries no technology condition.
+    applicability:
+      always: true
+      conditions:
+        - A source repository exists
+      not_applicable_when: []
+    framework_mappings:
+      nist_ssdf: [PO.5.2, PW.7.2, RV.1.1]
+      slsa: []
+      owasp_cicd: [CICD-SEC-6 Insufficient Credential Hygiene]
+      owasp_samm: [Verification — Security Testing, Operations — Environment Management]
+      cncf_supply_chain: [Securing the Source Code]
+    enforcement:
+      level: block
+      automatable: true
+    tooling:
+      examples:
+        - Any organizational secret-scanning capability (Gitleaks, TruffleHog, platform-native secret scanning)
+      prefer_existing_tool: true
+
+  - id: DSB-SCAN-005
+    title: Container and image scanning where a container image artifact is produced
+    phase: scan
+    requirement: >-
+      Container images built by the pipeline are scanned for vulnerabilities in OS
+      packages and application layers before publication or promotion.
+    rationale: >-
+      The image carries far more than the application — a base image can contribute
+      hundreds of packages the team never selected. Scanning the built image is the only
+      way to see what actually ships.
+    applicability:
+      always: false
+      conditions:
+        - The pipeline builds or publishes a container image
+      not_applicable_when:
+        - The workload produces no container image (library, serverless zip, static site,
+          OS package)
+    framework_mappings:
+      nist_ssdf: [PW.4.4, PS.1.1, RV.1.1]
+      slsa: []
+      owasp_cicd: [CICD-SEC-9 Improper Artifact Integrity Validation]
+      owasp_samm: [Verification — Security Testing]
+      cncf_supply_chain: [Securing Artefacts]
+    enforcement:
+      level: block
+      automatable: true
+    tooling:
+      examples:
+        - Any organizational image-scanning capability (Prisma Cloud, Trivy, Grype, Clair, registry-native scanning)
+      prefer_existing_tool: true
+
+  - id: DSB-SCAN-006
+    title: Infrastructure-as-code scanning where IaC exists
+    phase: scan
+    requirement: >-
+      Infrastructure-as-code definitions are scanned for insecure configuration before
+      the change is applied to any environment.
+    rationale: >-
+      IaC misconfiguration is provisioned risk — a public bucket or open security group
+      is created correctly and instantly by a working pipeline. Catching it before apply
+      is the only cheap moment.
+    applicability:
+      always: false
+      conditions:
+        - The repository contains infrastructure-as-code (Terraform, CloudFormation, Bicep, Pulumi, Ansible, CDK)
+      not_applicable_when:
+        - The workload declares no infrastructure
+        - Infrastructure is owned and delivered by a separate governed platform pipeline
+          (record as Satisfied — externally owned)
+    framework_mappings:
+      nist_ssdf: [PW.7.1, PO.5.1, PO.5.2]
+      slsa: []
+      owasp_cicd: [CICD-SEC-7 Insecure System Configuration]
+      owasp_samm: [Verification — Security Testing, Operations — Environment Management]
+      cncf_supply_chain: [Securing the Source Code]
+    enforcement:
+      level: block
+      automatable: true
+    tooling:
+      examples:
+        - Any organizational IaC-scanning capability (Checkov, tfsec, Trivy config, Terrascan, Prisma Cloud IaC)
+      prefer_existing_tool: true
+
+  - id: DSB-SCAN-007
+    title: Kubernetes and workload configuration scanning where Kubernetes resources exist
+    phase: scan
+    requirement: >-
+      Kubernetes manifests, Helm charts, Kustomize overlays, and equivalent workload
+      configuration are scanned against security and policy baselines before deployment.
+    rationale: >-
+      Kubernetes risk is overwhelmingly configuration risk — privileged containers, host
+      mounts, absent resource and network policy. None of it is visible to an image
+      scanner.
+    applicability:
+      always: false
+      conditions:
+        - The repository contains Kubernetes manifests, Helm charts, or equivalent workload configuration
+      not_applicable_when:
+        - The workload does not deploy to Kubernetes
+        - Cluster-level policy is enforced by a governed platform admission controller
+          (record as Satisfied — externally owned)
+    framework_mappings:
+      nist_ssdf: [PW.7.1, PO.5.1]
+      slsa: []
+      owasp_cicd: [CICD-SEC-7 Insecure System Configuration]
+      owasp_samm: [Operations — Environment Management]
+      cncf_supply_chain: [Securing Deployments]
+    enforcement:
+      level: block
+      automatable: true
+    tooling:
+      examples:
+        - Manifest and chart scanners (Kubescape, Trivy, Checkov, Datree)
+        - Policy-as-code engines (OPA/Gatekeeper, Kyverno)
+      prefer_existing_tool: true
+
+  - id: DSB-SCAN-008
+    title: CI/CD pipeline configuration scanning where pipeline definitions are in the repository
+    phase: scan
+    requirement: >-
+      Pipeline definitions stored in the repository are scanned for insecure
+      configuration — unpinned third-party components, over-privileged tokens,
+      injectable expressions, and untrusted-input execution paths.
+    rationale: >-
+      The pipeline is production infrastructure with credentials to source, artifacts,
+      and environments. It is a target, and it is the one piece of infrastructure teams
+      routinely exclude from their own scanning.
+    applicability:
+      always: false
+      conditions:
+        - Pipeline definitions are stored in the repository as code
+      not_applicable_when:
+        - The pipeline is configured entirely outside version control (itself a finding
+          against DSB-SRC-001)
+    framework_mappings:
+      nist_ssdf: [PO.3.2, PO.5.1, PW.7.1]
+      slsa: [Build L2 — hosted build platform]
+      owasp_cicd: [CICD-SEC-4 Poisoned Pipeline Execution, CICD-SEC-2 Inadequate Identity and Access Management, CICD-SEC-7 Insecure System Configuration]
+      owasp_samm: [Operations — Environment Management]
+      cncf_supply_chain: [Securing Build Pipelines]
+    enforcement:
+      level: warn
+      automatable: true
+    tooling:
+      examples:
+        - Pipeline configuration scanners (zizmor, Checkov CI, octoscan, Semgrep CI rules)
+      prefer_existing_tool: true
+
+  - id: DSB-SCAN-009
+    title: Dynamic and API security testing against a deployed, authorized environment
+    phase: scan
+    requirement: >-
+      Runtime-dependent security testing — DAST, API security testing, and equivalent —
+      executes after deployment to an appropriate testable environment. Active testing
+      against production is prohibited without explicit, documented organizational
+      authorization.
+    rationale: >-
+      These controls need a running system, which is why they follow deployment; they
+      remain part of Scan/verification rather than a fifth phase. The production
+      prohibition exists because active scanning is indistinguishable from an attack and
+      can cause real outages and real data mutation.
+    applicability:
+      always: false
+      conditions:
+        - The workload exposes an HTTP interface, API, or other network-reachable surface
+        - A non-production environment exists that is representative enough to test
+      not_applicable_when:
+        - The workload exposes no runtime interface (library, batch job, static content)
+        - No testable environment exists — record as a gap, not as satisfied
+    framework_mappings:
+      nist_ssdf: [PW.8.2, RV.1.1, RV.1.2]
+      slsa: []
+      owasp_cicd: []
+      owasp_samm: [Verification — Security Testing]
+      cncf_supply_chain: [Securing Deployments]
+    enforcement:
+      level: warn
+      automatable: true
+    tooling:
+      examples:
+        - DAST and API testing capabilities (OWASP ZAP, Burp Suite Enterprise, Invicti, StackHawk)
+      prefer_existing_tool: true
+
+  - id: DSB-SCAN-010
+    title: Minimum sufficient toolchain — no duplicate scanners for one capability
+    phase: scan
+    requirement: >-
+      A required capability is satisfied by exactly one tool unless a documented
+      engineering reason justifies overlap. Introducing a second scanner for a
+      capability an existing organizational tool already covers is a defect.
+    rationale: >-
+      Duplicate coverage multiplies findings, triage cost, and false positives without
+      adding assurance. It is the fastest way to make a pipeline slow enough that teams
+      start bypassing it — which costs more security than the second scanner ever
+      provided.
+    applicability:
+      always: true
+      conditions:
+        - Any pipeline is being designed, generated, or reviewed
+      not_applicable_when: []
+    framework_mappings:
+      nist_ssdf: [PO.3.1, RV.1.3]
+      slsa: []
+      owasp_cicd: [CICD-SEC-8 Ungoverned Usage of Third Party Services]
+      owasp_samm: [Governance — Strategy and Metrics]
+      cncf_supply_chain: []
+    enforcement:
+      level: warn
+      automatable: false
+    tooling:
+      examples: []
+      prefer_existing_tool: true

--- a/devsecops-engineering-skill/rules/source.yaml
+++ b/devsecops-engineering-skill/rules/source.yaml
@@ -1,0 +1,98 @@
+# DSB DevSecOps Engineering Rules — Source
+# Cross-cutting: the repository as the origin of everything downstream.
+family: DSB-SRC
+scope: Source control and repository security
+rules:
+  - id: DSB-SRC-001
+    title: All delivery-relevant code and configuration lives in version control
+    phase: cross-cutting
+    requirement: >-
+      Application source, infrastructure-as-code, pipeline definitions, and deployment
+      configuration are stored in version control. Pipeline logic configured only
+      through a web UI, and infrastructure changed only by hand, are findings.
+    rationale: >-
+      Anything outside version control has no history, no review, no rollback, and no
+      scan coverage. It is also the part of the system nobody can reconstruct after an
+      incident.
+    applicability:
+      always: true
+      conditions:
+        - A delivery pipeline exists
+      not_applicable_when: []
+    framework_mappings:
+      nist_ssdf: [PO.3.2, PS.1.1, PS.3.1]
+      slsa: [Build L1 — scripted build]
+      owasp_cicd: [CICD-SEC-1 Insufficient Flow Control Mechanisms]
+      owasp_samm: [Implementation — Secure Build]
+      cncf_supply_chain: [Securing the Source Code]
+    enforcement:
+      level: block
+      automatable: false
+    tooling:
+      examples:
+        - Any version control platform (GitHub, GitLab, Bitbucket, Azure Repos)
+      prefer_existing_tool: true
+
+  - id: DSB-SRC-002
+    title: Protected branches require review and passing checks before merge
+    phase: cross-cutting
+    requirement: >-
+      Branches that feed deployable builds are protected: direct pushes are prevented,
+      changes require review by someone other than the author, and the pipeline's
+      required checks must pass before merge.
+    rationale: >-
+      Branch protection is the enforcement point that makes every pipeline gate
+      unavoidable. Without it, the gates are advisory and any contributor can route
+      around them by pushing to the branch directly.
+    applicability:
+      always: false
+      conditions:
+        - A branch is used as the source for deployable builds
+      not_applicable_when:
+        - The repository produces nothing deployable
+    framework_mappings:
+      nist_ssdf: [PO.3.2, PW.7.1, PS.1.1]
+      slsa: [Build L2 — source integrity]
+      owasp_cicd: [CICD-SEC-1 Insufficient Flow Control Mechanisms, CICD-SEC-5 Insufficient PBAC]
+      owasp_samm: [Implementation — Secure Build, Verification — Security Testing]
+      cncf_supply_chain: [Securing the Source Code]
+    enforcement:
+      level: block
+      automatable: true
+    tooling:
+      examples:
+        - Platform-native branch protection or merge request approval rules
+        - Required status checks bound to pipeline jobs
+      prefer_existing_tool: true
+
+  - id: DSB-SRC-003
+    title: Repository access and automation tokens follow least privilege
+    phase: cross-cutting
+    requirement: >-
+      Human and machine access to repositories is scoped to need. Automation tokens and
+      bot accounts are narrowly permissioned, individually attributable, and rotated or
+      short-lived. Security-relevant paths — pipeline definitions, IaC, policy — carry
+      explicit ownership requiring review.
+    rationale: >-
+      Broad repository write access is equivalent to deployment access once a pipeline
+      exists. Ownership rules on pipeline and policy paths stop the controls themselves
+      from being edited without a security reviewer seeing it.
+    applicability:
+      always: true
+      conditions:
+        - A source repository exists
+      not_applicable_when: []
+    framework_mappings:
+      nist_ssdf: [PO.2.1, PO.5.1, PS.1.1]
+      slsa: [Build L2 — source integrity]
+      owasp_cicd: [CICD-SEC-2 Inadequate Identity and Access Management, CICD-SEC-6 Insufficient Credential Hygiene]
+      owasp_samm: [Governance — Policy and Compliance]
+      cncf_supply_chain: [Securing the Source Code]
+    enforcement:
+      level: warn
+      automatable: false
+    tooling:
+      examples:
+        - CODEOWNERS or equivalent path-based review requirements
+        - Scoped deploy keys, app installations, and fine-grained tokens
+      prefer_existing_tool: true

--- a/devsecops-engineering-skill/rules/supply-chain.yaml
+++ b/devsecops-engineering-skill/rules/supply-chain.yaml
@@ -1,0 +1,101 @@
+# DSB DevSecOps Engineering Rules — Supply Chain
+# What enters the build, and what the build can prove about itself.
+family: DSB-SC
+scope: Software supply chain security
+rules:
+  - id: DSB-SC-001
+    title: An SBOM is generated for every released artifact
+    phase: build
+    requirement: >-
+      A software bill of materials in a standard format is produced for each artifact
+      the pipeline releases, and is stored alongside or attached to that artifact.
+    rationale: >-
+      An SBOM is what turns "are we affected by this new CVE?" from a multi-day
+      investigation into a query. It has to be generated at build time, because that is
+      the only moment the full resolved dependency set is known.
+    applicability:
+      always: false
+      conditions:
+        - The pipeline releases an artifact that contains third-party components
+      not_applicable_when:
+        - The pipeline releases no artifact
+    framework_mappings:
+      nist_ssdf: [PS.3.2, PW.4.1, RV.1.2]
+      slsa: [Provenance — available]
+      owasp_cicd: [CICD-SEC-3 Dependency Chain Abuse]
+      owasp_samm: [Implementation — Secure Build, Operations — Operational Management]
+      cncf_supply_chain: [Securing Materials, Securing Artefacts]
+    enforcement:
+      level: warn
+      automatable: true
+    tooling:
+      examples:
+        - SBOM generators emitting SPDX or CycloneDX (Syft, Trivy, cdxgen, build-tool plugins)
+      prefer_existing_tool: true
+
+  - id: DSB-SC-002
+    title: Third-party pipeline components are pinned to immutable versions
+    phase: build
+    requirement: >-
+      Reusable actions, plugins, templates, base images, and modules consumed by the
+      pipeline are pinned to an immutable reference — a commit SHA or digest — and
+      sourced from governed or explicitly allow-listed origins.
+    rationale: >-
+      A mutable tag on a third-party action is remote code execution scheduled for
+      whenever its maintainer's account is compromised. Pinning to a digest is the
+      difference between reviewing a dependency once and trusting it forever.
+    applicability:
+      always: false
+      conditions:
+        - The pipeline consumes any third-party action, plugin, template, module, or base image
+      not_applicable_when:
+        - The pipeline consumes no third-party components
+    framework_mappings:
+      nist_ssdf: [PW.4.1, PW.4.4, PO.3.1]
+      slsa: [Build L2 — provenance of build inputs, Build L3 — hardened builds]
+      owasp_cicd: [CICD-SEC-3 Dependency Chain Abuse, CICD-SEC-8 Ungoverned Usage of Third Party Services, CICD-SEC-4 Poisoned Pipeline Execution]
+      owasp_samm: [Implementation — Secure Build]
+      cncf_supply_chain: [Securing Materials, Securing Build Pipelines]
+    enforcement:
+      level: block
+      automatable: true
+    tooling:
+      examples:
+        - SHA-pinned workflow references and digest-pinned base images
+        - Automated pin-updating bots (Dependabot, Renovate)
+        - Internal mirrors and allow-listed registries
+      prefer_existing_tool: true
+
+  - id: DSB-SC-003
+    title: Build provenance is generated and verifiable where the platform supports it
+    phase: build
+    requirement: >-
+      Where the CI/CD platform can produce build provenance or attestations, the
+      pipeline generates them for released artifacts, and consumers verify them before
+      deployment.
+    rationale: >-
+      Provenance is what lets a deploying system prove an artifact came from the
+      pipeline it claims to, rather than from someone with push access to the registry.
+      Generating it without verifying it provides no security value.
+    applicability:
+      always: false
+      conditions:
+        - The pipeline releases an artifact
+        - The platform supports provenance or attestation generation
+      not_applicable_when:
+        - The platform provides no provenance mechanism — record as a gap with the
+          compensating controls in place
+    framework_mappings:
+      nist_ssdf: [PS.3.1, PS.3.2, PW.6.2]
+      slsa: [Provenance — available, Provenance — authenticated, Build L3 — non-falsifiable provenance]
+      owasp_cicd: [CICD-SEC-9 Improper Artifact Integrity Validation]
+      owasp_samm: [Implementation — Secure Build, Implementation — Secure Deployment]
+      cncf_supply_chain: [Securing Artefacts, Securing Build Pipelines]
+    enforcement:
+      level: report
+      automatable: true
+    tooling:
+      examples:
+        - SLSA provenance generators and platform-native attestation
+        - in-toto attestations, Sigstore Cosign attestation and verification
+      prefer_existing_tool: true

--- a/devsecops-engineering-skill/rules/test.yaml
+++ b/devsecops-engineering-skill/rules/test.yaml
@@ -1,0 +1,96 @@
+# DSB DevSecOps Engineering Rules — Test
+# Phase: Test. Workload-appropriate validation that the deliverable behaves correctly.
+family: DSB-TEST
+scope: Testing
+rules:
+  - id: DSB-TEST-001
+    title: Workload-appropriate automated tests execute in the pipeline
+    phase: test
+    requirement: >-
+      The pipeline executes the project's automated tests using the frameworks and
+      commands native to the project. Test selection reflects what the workload actually
+      is — a library, a service, an infrastructure module, and a batch job do not have
+      the same meaningful test surface.
+    rationale: >-
+      Testing validates that the thing you built does what it is supposed to do.
+      Scanning cannot answer that question. A pipeline that skips testing is deploying
+      unvalidated behavior no matter how many scanners it runs.
+    applicability:
+      always: false
+      conditions:
+        - The workload has behavior that can be meaningfully validated before deployment
+      not_applicable_when:
+        - The repository is documentation, configuration, or content only
+    framework_mappings:
+      nist_ssdf: [PW.7.2, PW.8.1, PW.8.2]
+      slsa: []
+      owasp_cicd: []
+      owasp_samm: [Verification — Requirements-driven Testing]
+      cncf_supply_chain: []
+    enforcement:
+      level: block
+      automatable: true
+    tooling:
+      examples:
+        - Project-native frameworks (JUnit, pytest, Jest, Go test, RSpec)
+        - Infrastructure test tooling where the workload is IaC (Terratest, native plan validation)
+      prefer_existing_tool: true
+
+  - id: DSB-TEST-002
+    title: Testing and scanning remain conceptually separate
+    phase: test
+    requirement: >-
+      Security scanning must not be counted as satisfying the Test phase, and functional
+      testing must not be counted as satisfying the Scan phase. Each phase is assessed
+      against its own rules.
+    rationale: >-
+      Collapsing the two is the most common way a pipeline appears complete while
+      validating nothing. A SAST run tells you nothing about whether the feature works;
+      a passing unit test tells you nothing about a vulnerable transitive dependency.
+    applicability:
+      always: true
+      conditions:
+        - Any pipeline is being designed, generated, or reviewed
+      not_applicable_when: []
+    framework_mappings:
+      nist_ssdf: [PW.7.1, PW.8.2]
+      slsa: []
+      owasp_cicd: []
+      owasp_samm: [Verification — Security Testing]
+      cncf_supply_chain: []
+    enforcement:
+      level: block
+      automatable: false
+    tooling:
+      examples: []
+      prefer_existing_tool: true
+
+  - id: DSB-TEST-003
+    title: No meaningless tests written to satisfy the phase
+    phase: test
+    requirement: >-
+      Tests that assert nothing of value about the workload must not be introduced
+      solely to make the Test phase appear satisfied. Where no meaningful automated test
+      exists, record the phase as Not Applicable with justification rather than
+      fabricating coverage.
+    rationale: >-
+      A trivially passing test suite is worse than an honest gap: it produces a green
+      signal that suppresses the conversation about real coverage, and it is expensive
+      to maintain forever.
+    applicability:
+      always: true
+      conditions:
+        - The Test phase is being designed or assessed
+      not_applicable_when: []
+    framework_mappings:
+      nist_ssdf: [PW.8.2, RV.2.2]
+      slsa: []
+      owasp_cicd: []
+      owasp_samm: [Verification — Requirements-driven Testing]
+      cncf_supply_chain: []
+    enforcement:
+      level: warn
+      automatable: false
+    tooling:
+      examples: []
+      prefer_existing_tool: true

--- a/devsecops-engineering-skill/scripts/validate_rules.py
+++ b/devsecops-engineering-skill/scripts/validate_rules.py
@@ -1,0 +1,237 @@
+#!/usr/bin/env python3
+"""Validate the DSB DevSecOps engineering rule catalog.
+
+Checks every rule file in rules/ for schema conformance so that malformed or
+drifting rules cannot reach a release. Run it directly, or via CI:
+
+    uv run --with pyyaml python scripts/validate_rules.py
+
+Exit code 0 on success, 1 on any validation failure.
+"""
+
+from __future__ import annotations
+
+import sys
+from pathlib import Path
+
+try:
+    import yaml
+except ModuleNotFoundError:  # pragma: no cover - environment guard
+    sys.exit(
+        "PyYAML is required.\n"
+        "  pip install pyyaml            # or\n"
+        "  uv run --with pyyaml python scripts/validate_rules.py"
+    )
+
+RULES_DIR = Path(__file__).resolve().parent.parent / "rules"
+
+# The four delivery phases, plus 'cross-cutting' for governance rules that
+# constrain the pipeline as a whole rather than one phase of it.
+ALLOWED_PHASES = {"build", "test", "scan", "deploy", "cross-cutting"}
+
+# N/A is a runtime outcome recorded per workload (DSB-EVD-003), never a
+# per-rule default, so it is not a valid value here.
+ALLOWED_ENFORCEMENT_LEVELS = {"block", "warn", "report"}
+
+REQUIRED_FRAMEWORK_KEYS = {
+    "nist_ssdf",
+    "slsa",
+    "owasp_cicd",
+    "owasp_samm",
+    "cncf_supply_chain",
+}
+
+REQUIRED_RULE_FIELDS = (
+    "id",
+    "title",
+    "phase",
+    "requirement",
+    "rationale",
+    "applicability",
+    "framework_mappings",
+    "enforcement",
+    "tooling",
+)
+
+# Family -> expected rule count. Guards against accidental additions or
+# deletions; update deliberately alongside a CHANGELOG entry.
+EXPECTED_FAMILIES = {
+    "DSB-BUILD": 4,
+    "DSB-TEST": 3,
+    "DSB-SCAN": 10,
+    "DSB-DEPLOY": 4,
+    "DSB-ID": 3,
+    "DSB-SRC": 3,
+    "DSB-SC": 3,
+    "DSB-ART": 4,
+    "DSB-IAC": 3,
+    "DSB-EVD": 3,
+    "DSB-EXC": 2,
+}
+EXPECTED_TOTAL = sum(EXPECTED_FAMILIES.values())
+
+
+def validate_rule(rule: dict, family: str, path: Path, errors: list[str]) -> str | None:
+    """Validate one rule; return its id if usable for uniqueness checks."""
+    where = f"{path.name}"
+    rule_id = rule.get("id", "<missing id>")
+
+    for field in REQUIRED_RULE_FIELDS:
+        if field not in rule:
+            errors.append(f"{where}: {rule_id}: missing required field '{field}'")
+
+    if not isinstance(rule_id, str) or not rule_id.startswith(f"{family}-"):
+        errors.append(f"{where}: rule id '{rule_id}' does not carry family prefix '{family}-'")
+
+    for field in ("title", "requirement", "rationale"):
+        value = rule.get(field)
+        if field in rule and (not isinstance(value, str) or not value.strip()):
+            errors.append(f"{where}: {rule_id}: '{field}' must be a non-empty string")
+
+    phase = rule.get("phase")
+    if "phase" in rule and phase not in ALLOWED_PHASES:
+        errors.append(
+            f"{where}: {rule_id}: phase '{phase}' not in {sorted(ALLOWED_PHASES)}"
+        )
+
+    applicability = rule.get("applicability")
+    if "applicability" in rule:
+        if not isinstance(applicability, dict):
+            errors.append(f"{where}: {rule_id}: 'applicability' must be a mapping")
+        else:
+            if not isinstance(applicability.get("always"), bool):
+                errors.append(f"{where}: {rule_id}: applicability.always must be a boolean")
+            for key in ("conditions", "not_applicable_when"):
+                if not isinstance(applicability.get(key), list):
+                    errors.append(f"{where}: {rule_id}: applicability.{key} must be a list")
+            if applicability.get("always") is False and not applicability.get("conditions"):
+                errors.append(
+                    f"{where}: {rule_id}: conditional rule must state at least one condition"
+                )
+
+    mappings = rule.get("framework_mappings")
+    if "framework_mappings" in rule:
+        if not isinstance(mappings, dict):
+            errors.append(f"{where}: {rule_id}: 'framework_mappings' must be a mapping")
+        else:
+            missing = REQUIRED_FRAMEWORK_KEYS - set(mappings)
+            unknown = set(mappings) - REQUIRED_FRAMEWORK_KEYS
+            if missing:
+                errors.append(
+                    f"{where}: {rule_id}: framework_mappings missing keys {sorted(missing)}"
+                )
+            if unknown:
+                errors.append(
+                    f"{where}: {rule_id}: framework_mappings has unknown keys {sorted(unknown)}"
+                )
+            for key, value in mappings.items():
+                if not isinstance(value, list):
+                    errors.append(
+                        f"{where}: {rule_id}: framework_mappings.{key} must be a list"
+                    )
+
+    enforcement = rule.get("enforcement")
+    if "enforcement" in rule:
+        if not isinstance(enforcement, dict):
+            errors.append(f"{where}: {rule_id}: 'enforcement' must be a mapping")
+        else:
+            level = enforcement.get("level")
+            if level not in ALLOWED_ENFORCEMENT_LEVELS:
+                errors.append(
+                    f"{where}: {rule_id}: enforcement.level '{level}' not in "
+                    f"{sorted(ALLOWED_ENFORCEMENT_LEVELS)}"
+                )
+            if not isinstance(enforcement.get("automatable"), bool):
+                errors.append(f"{where}: {rule_id}: enforcement.automatable must be a boolean")
+
+    tooling = rule.get("tooling")
+    if "tooling" in rule:
+        if not isinstance(tooling, dict):
+            errors.append(f"{where}: {rule_id}: 'tooling' must be a mapping")
+        else:
+            if not isinstance(tooling.get("examples"), list):
+                errors.append(f"{where}: {rule_id}: tooling.examples must be a list")
+            # Capability-based, never vendor-based: the preference for an existing
+            # organizational tool is a property of every rule in the catalog.
+            if tooling.get("prefer_existing_tool") is not True:
+                errors.append(
+                    f"{where}: {rule_id}: tooling.prefer_existing_tool must be true"
+                )
+
+    return rule_id if isinstance(rule_id, str) else None
+
+
+def main() -> int:
+    errors: list[str] = []
+    seen_ids: dict[str, str] = {}
+    counts: dict[str, int] = {}
+
+    rule_files = sorted(RULES_DIR.glob("*.yaml"))
+    if not rule_files:
+        print(f"FAIL: no rule files found in {RULES_DIR}")
+        return 1
+
+    for path in rule_files:
+        try:
+            doc = yaml.safe_load(path.read_text(encoding="utf-8"))
+        except yaml.YAMLError as exc:
+            errors.append(f"{path.name}: YAML parse error: {exc}")
+            continue
+
+        if not isinstance(doc, dict):
+            errors.append(f"{path.name}: top level must be a mapping")
+            continue
+
+        family = doc.get("family")
+        if not isinstance(family, str) or not family.startswith("DSB-"):
+            errors.append(f"{path.name}: 'family' must be a DSB-prefixed string")
+            continue
+        if not isinstance(doc.get("scope"), str) or not doc.get("scope", "").strip():
+            errors.append(f"{path.name}: 'scope' must be a non-empty string")
+
+        rules = doc.get("rules")
+        if not isinstance(rules, list) or not rules:
+            errors.append(f"{path.name}: 'rules' must be a non-empty list")
+            continue
+
+        for rule in rules:
+            if not isinstance(rule, dict):
+                errors.append(f"{path.name}: every rule must be a mapping")
+                continue
+            rule_id = validate_rule(rule, family, path, errors)
+            if rule_id:
+                if rule_id in seen_ids:
+                    errors.append(
+                        f"{path.name}: duplicate rule id '{rule_id}' "
+                        f"(already defined in {seen_ids[rule_id]})"
+                    )
+                else:
+                    seen_ids[rule_id] = path.name
+
+        counts[family] = counts.get(family, 0) + len(rules)
+
+    for family, expected in EXPECTED_FAMILIES.items():
+        actual = counts.get(family)
+        if actual is None:
+            errors.append(f"family {family} is missing from the catalog")
+        elif actual != expected:
+            errors.append(f"family {family}: expected {expected} rules, found {actual}")
+    for family in set(counts) - set(EXPECTED_FAMILIES):
+        errors.append(f"unexpected family '{family}' — add it to EXPECTED_FAMILIES first")
+
+    total = sum(counts.values())
+
+    if errors:
+        print(f"FAIL: {len(errors)} validation error(s)\n")
+        for error in errors:
+            print(f"  - {error}")
+        return 1
+
+    print(f"OK — {total} rules across {len(counts)} families")
+    for family in sorted(counts, key=lambda f: (-counts[f], f)):
+        print(f"  {family:<12} {counts[family]:>2}")
+    return 0
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/docs/DevSec Blueprint — DevSecOps Engineering Skill.md
+++ b/docs/DevSec Blueprint — DevSecOps Engineering Skill.md
@@ -1,0 +1,279 @@
+# DevSec Blueprint — DevSecOps Engineering Skill
+
+**Implementation Report**
+
+| | |
+|---|---|
+| **Repository** | `devsecblueprint/devsecops-claude-skill` — verified live (public, 1 commit, 5 open PRs) |
+| **Owner** | The DevSec Blueprint |
+| **Date** | 2026-08-16 |
+| **Target release** | v0.1.0 (Pre-1.0) |
+| **Status** | ✅ Scaffold complete + v0.1.0 required changes implemented — 42 rules across 11 families, validation passing |
+
+---
+
+## 0. Verification of v0.1.0 Maintainer Feedback
+
+Feedback from @leeclay95 was verified against live sources on 2026-08-16:
+
+| Claim | Verification result |
+|---|---|
+| Repository exists under `devsecblueprint` | ✅ **Confirmed** — `devsecops-claude-skill`, public, listed in the org's 26 repositories. Corrects earlier report status ("pending push") — the repo already exists. |
+| Current license is PolyForm Noncommercial | ✅ **Confirmed** — repo README states "PolyForm Noncommercial License 1.0.0" with commercial authorization required via `docs/legal/COMMERCIAL-LICENSING.md`; GitHub shows license "Other". |
+| `MAINTAINERS.md` and legal/licensing docs exist and reference commercial terms | ✅ **Confirmed** — `MAINTAINERS.md`, `LICENSE.md`, `docs/legal/` (commercial licensing + trademarks) present in the repo. |
+| No command entry points yet | ✅ **Confirmed** — repo has no `commands/` directory or plugin manifest; skill is a single self-contained `SKILL.md`. |
+| GRC Engineering Club Claude repo as README reference model | ✅ **Confirmed** — `GRCEngClub/claude-grc-engineering`, an open-source Claude Code plugin toolkit whose command/plugin convention matches the requested `/devsecops-engineer:*` namespace pattern. |
+| No release tagged yet | ✅ **Confirmed** — repo shows no releases/tags, consistent with preparing v0.1.0 as the initial release. |
+
+### 0a. v0.1.0 Required Changes — Implementation Status
+
+| # | Required change | Status | Implementation |
+|---|---|---|---|
+| 1 | MIT license replacing PolyForm Noncommercial, all references updated | ✅ Implemented in scaffold | `LICENSE` (MIT), `README.md` license section, new `MAINTAINERS.md` (MIT attribution, no commercial-authorization language), `docs/legal/TRADEMARKS.md` keeping DSB branding/trademarks/curriculum separate from the MIT-licensed implementation |
+| 2 | Command entry points `/devsecops-engineer:assess`, `:design`, `:advise` | ✅ Implemented | `commands/assess.md`, `commands/design.md`, `commands/advise.md` + `.claude-plugin/plugin.json` (name: `devsecops-engineer` — namespace chosen to match the planned `/cloud-security-engineer:*` convention). Each command is a thin wrapper that loads `SKILL.md` and its rule catalog; a "commands stay thin — no rule logic" policy was added to `CONTRIBUTING.md` to prevent drift |
+| 3 | README as product-oriented front door (GRC-club-quality IA, DSB-branded) | ✅ Implemented | Rewritten `README.md` following the required flow: What is this? → Why use it (outcomes) → Install in 60 seconds → Try it (Assess/Design/Advise prompts) → Common workflows → How it works (workload profiling → applicability → capability resolution → enforcement → placement) → Go deeper (links to examples, rules, mappings, testing, contributing) → v0.1.0/Pre-1.0 status → MIT + DSB ownership |
+| 4 | Initial release as v0.1.0, not v1.0.0 | ✅ Implemented | `plugin.json` version `0.1.0`, `CHANGELOG.md` v0.1.0 entry with explicit Pre-1.0 evolution language, status language in README |
+| — | Validation/behavioral tests still pass | ✅ | `validate_rules.py`: OK — 42 rules across 11 families |
+
+These changes are implemented in the local scaffold (`devsecops-engineering-skill/`, packaged as `dsb-devsecops-engineering-v0.1.0.skill`) and are ready to be applied to the live `devsecops-claude-skill` repository as a PR, followed by tagging v0.1.0.
+
+---
+
+## 1. Summary
+
+A dedicated, DevSec Blueprint-owned Claude Skill repository was scaffolded to teach, advise on, design, generate, and review DevSecOps delivery pipelines using the engineering methodology taught throughout The DevSec Blueprint. The skill encodes a consistent set of DSB DevSecOps engineering rules while remaining flexible across organizations, CI/CD platforms, cloud environments, application architectures, security products, and internal operating models.
+
+This is not a generic pipeline generator and prescribes no DSB-approved vendor stack: DSB defines the required capabilities and engineering outcomes; the organization determines how those capabilities are implemented. The skill is strongly associated with The DevSec Blueprint — no separate product name, mascot, or sub-brand was introduced.
+
+> **Build what you need. Test what you built. Scan what can introduce meaningful risk. Deploy only what passed.**
+
+---
+
+## 2. Repository Requirement — Status
+
+The repository is scaffolded as a standalone codebase, independent from the primary DSB application repository, ready to be created under the `devsecblueprint` GitHub organization. The name `devsecops-engineering-skill` describes the skill while keeping The DevSec Blueprint as the primary brand.
+
+| Requirement | Status | Where |
+|---|---|---|
+| Created under `devsecblueprint` org | ⏳ Pending push (only manual step remaining) | — |
+| Clear DSB branding and ownership attribution | ✅ | `README.md`, `SKILL.md`, `CONTRIBUTING.md` |
+| Skill definition and supporting resources | ✅ | `SKILL.md`, `references/` |
+| DSB DevSecOps rule catalog | ✅ | `rules/*.yaml` (42 rules, 11 families) |
+| Framework/best-practice mappings | ✅ | per-rule `framework_mappings` + `references/framework-mappings.md` |
+| Representative examples and reference implementations | ✅ | `examples/` (Advise, Generate ×2, Review) |
+| Contributor and maintenance documentation | ✅ | `CONTRIBUTING.md` |
+| DSB-approved license and contributor requirements | ✅ MIT (confirm as DSB-approved) | `LICENSE`, `CONTRIBUTING.md` |
+| Independent from primary DSB application codebase | ✅ | Standalone repository |
+
+---
+
+## 3. Core DSB Methodology — Implementation
+
+Every delivery pipeline follows four logical phases, encoded in `SKILL.md` and enforced by the rule catalog. They describe engineering intent, not job structure, vendor, or platform.
+
+```
+BUILD → TEST → SCAN → DEPLOY
+```
+
+| Phase | Encoding | Key rules |
+|---|---|---|
+| **Build** — repeatable, traceable deliverable preparation (compilation, dependency resolution, packaging, images, IaC preparation, artifact generation) | `SKILL.md` + `rules/build.yaml` | `DSB-BUILD-001..004` |
+| **Test** — workload-appropriate behavior validation; conceptually separate from scanning; prefers project-native tests; no meaningless tests to satisfy the phase | `rules/test.yaml` | `DSB-TEST-001..003` |
+| **Scan** — non-negotiable; scanners required only when the associated technology, artifact, or risk exists; minimum sufficient toolchain | `rules/scan.yaml` | `DSB-SCAN-001..010` |
+| **Deploy** — deliver/promote only artifacts that passed applicable Build, Test, Scan requirements (deployment, publication, promotion) | `rules/deploy.yaml` | `DSB-DEPLOY-001..004` |
+
+Runtime-dependent controls (DAST, API security testing, runtime validation) execute post-deployment to an appropriate testable environment — part of Scan/verification, not a fifth phase (`DSB-SCAN-009`, `DSB-DEPLOY-004`). Active DAST against production without explicit organizational authorization is prohibited in both the rules and every example.
+
+---
+
+## 4. Operating Modes — Implementation
+
+Repository access is not required for the skill to provide value (stated in `SKILL.md`; all modes operate from user-supplied context).
+
+| Mode | Behavior implemented | Worked example |
+|---|---|---|
+| **1. Advise** | Maps org capabilities into Build → Test → Scan → Deploy, identifies gaps, recommends enforcement points, explains decisions with DSB rule IDs | `examples/advise/jenkins-java-enterprise.md` (the Jenkins/Java/Maven/Artifactory/Checkmarx/Black Duck/Prisma/OpenShift scenario from the issue) |
+| **2. Design / Generate** | Produces implementation-ready pipelines (GitHub Actions, Jenkins, GitLab CI, Azure DevOps, others); DSB rules constant, implementation adapts; asks for or states assumptions on missing context; annotates generated code with rule references | `examples/generate/github-actions-node-container.md`, `examples/generate/gitlab-ci-terraform.md` |
+| **3. Review** | Fixed findings structure identifying satisfied controls, missing capabilities, inappropriate enforcement, duplicate tooling, pipeline security weaknesses, DSB rule IDs, remediation, and intentional N/A | `examples/review/jenkinsfile-review.md` |
+
+---
+
+## 5. Tooling Philosophy and No-Bloat Behavior
+
+Capability-based, never vendor-based: every rule's `tooling.examples` is explicitly illustrative, with `prefer_existing_tool: true` throughout. The existing-tool decision pattern from the issue (Required Capability → Existing Organizational Tool → Decision → DSB Requirement: Satisfied) is embedded in `SKILL.md` and modeled in the Advise example.
+
+No-bloat behavior is enforced by `DSB-SCAN-010` (minimum sufficient toolchain, no duplicate scanners) and the applicability logic:
+
+- No container scanner without a container artifact
+- No IaC scanner without IaC
+- No Kubernetes scanner without Kubernetes
+- No duplicate SCA when an existing capability satisfies the control
+
+**Not Applicable** is a first-class, explicitly documented outcome (`DSB-EVD-003`), demonstrated in all examples. Custom/proprietary/internal security tools satisfy DSB rules without any rule changes.
+
+---
+
+## 6. Security Capability Catalog
+
+Implemented in `references/capability-catalog.md` with applicability conditions, earliest-valid placement, and owning DSB rule for each capability:
+
+- **Application and repository security** — SAST, SCA, secret scanning, dependency/package analysis, license/compliance analysis where required
+- **Infrastructure and platform security** — IaC scanning, Kubernetes/configuration scanning, policy-as-code enforcement, CI/CD pipeline configuration scanning
+- **Artifact and supply chain security** — container/image scanning, SBOM generation, artifact integrity verification, signing where required, provenance/build attestations where supported
+- **Dynamic / post-deployment security** — DAST, API security testing, post-deployment validation, runtime validation
+- **Advanced / organization-dependent** — fuzz testing, IAST, specialized compliance scanners, proprietary/internal tools, penetration testing workflows; incorporated when workload context, policy, or organizational requirements make them applicable — not baseline
+
+Placement principle encoded: security controls execute at the earliest technically valid stage where they produce meaningful results.
+
+---
+
+## 7. Rule Catalog (DSB Requirements Model)
+
+All 11 rule families from the issue are implemented. Every rule contains the full issue-specified schema: `id`, `title`, `phase`, `requirement`, `rationale`, `applicability`, `framework_mappings`, `enforcement.level`, `enforcement.automatable`, `tooling.examples`, `tooling.prefer_existing_tool`.
+
+| Family | File | Rules | Scope |
+|---|---|---:|---|
+| `DSB-BUILD-*` | `rules/build.yaml` | 4 | Build and artifact creation |
+| `DSB-TEST-*` | `rules/test.yaml` | 3 | Testing |
+| `DSB-SCAN-*` | `rules/scan.yaml` | 10 | Security scanning and validation |
+| `DSB-DEPLOY-*` | `rules/deploy.yaml` | 4 | Deployment and promotion |
+| `DSB-ID-*` | `rules/identity.yaml` | 3 | Workload identity, authn/authz |
+| `DSB-SRC-*` | `rules/source.yaml` | 3 | Source control and repository security |
+| `DSB-SC-*` | `rules/supply-chain.yaml` | 3 | Software supply chain security |
+| `DSB-ART-*` | `rules/artifacts.yaml` | 4 | Artifacts, provenance, signing, registries |
+| `DSB-IAC-*` | `rules/iac.yaml` | 3 | Infrastructure-as-code security |
+| `DSB-EVD-*` | `rules/evidence.yaml` | 3 | Evidence, logging, observability |
+| `DSB-EXC-*` | `rules/exceptions.yaml` | 2 | Exceptions and risk acceptance |
+| **Total** | | **42** | |
+
+All 20 Baseline DSB Engineering Principles from the issue are enumerated verbatim in `SKILL.md` and traceable to rules. The taxonomy may be refined during implementation per the issue; rule IDs are stable once merged (deprecate, never renumber — `CONTRIBUTING.md`).
+
+---
+
+## 8. Enforcement Model
+
+Implemented in `references/enforcement-model.md` and as per-rule defaults, with the issue's four outcomes:
+
+| Outcome | Meaning |
+|---|---|
+| **BLOCK** | Cannot continue without satisfaction or approved exception |
+| **WARN** | Surfaced, non-blocking |
+| **REPORT** | Evidence only |
+| **N/A** | Intentionally inapplicable, justified |
+
+Control **applicability** (engineering, workload-driven) is explicitly distinguished from control **enforcement** (policy, organization-driven); DSB defaults are recommendations the organization's enforcement policy may adjust. The exception path is governed by `DSB-EXC-001/002` (named approver, scope, expiry).
+
+---
+
+## 9. External Standards and Framework Mapping
+
+```
+Industry Standards / Best Practices
+              ↓
+DSB DevSecOps Engineering Methodology
+              ↓
+DSB Rules
+              ↓
+Organizational Context
+              ↓
+Platform / Tool Implementation
+```
+
+All five initial authoritative references are mapped per rule and cross-referenced in `references/framework-mappings.md`:
+
+- NIST SSDF (SP 800-218)
+- SLSA
+- OWASP CI/CD Security (Top 10 CI/CD Security Risks)
+- OWASP SAMM
+- CNCF Software Supply Chain Security guidance
+
+Frameworks inform the methodology; they do not replace engineering judgment or dictate pipeline architecture. Compliance framework mapping is deferred by design, and compliance is not the methodology's driver.
+
+---
+
+## 10. Organizational Context and Ownership Boundaries
+
+`references/applicability.md` implements the five-step selection flow:
+
+1. Workload inventory
+2. Applicability tests
+3. Existing-capability check
+4. Ownership-boundary check
+5. Organizational-context factors (platform, architecture, language, package manager, cloud, deployment platform, registries, existing products, policies, environment strategy, responsibility separation, risk tolerance, compliance)
+
+A control need not execute in the application pipeline when another governed organizational process legitimately owns and enforces it; the skill marks such controls **Satisfied (externally owned)** with the owning process named, rather than duplicating them. This pattern is demonstrated in the Advise, Generate, and Review examples.
+
+---
+
+## 11. Deliverables Traceability
+
+| # | Deliverable (from issue) | Status | Evidence |
+|---|---|---|---|
+| 1 | New dedicated GitHub repo under `devsecblueprint` | ⏳ Ready to push | Full scaffold complete |
+| 2 | Repo structure, branding, attribution, license, contributor/maintenance docs | ✅ | `README.md`, `LICENSE`, `CONTRIBUTING.md` |
+| 3 | Initial DSB DevSecOps engineering rule catalog | ✅ | `rules/` — 42 rules, 11 families |
+| 4 | Map initial rules to external standards/guidance | ✅ | Per-rule mappings + `references/framework-mappings.md` |
+| 5 | Rule applicability logic | ✅ | `references/applicability.md`, per-rule `applicability` |
+| 6 | BLOCK / WARN / REPORT / N/A enforcement semantics | ✅ | `references/enforcement-model.md`, per-rule defaults |
+| 7 | Security capability catalog | ✅ | `references/capability-catalog.md` |
+| 8 | Workload- and context-driven control selection | ✅ | Selection algorithm in `SKILL.md` + applicability doc |
+| 9 | Existing-tool preference / no-bloat behavior | ✅ | `DSB-SCAN-010`, `prefer_existing_tool`, applicability step 3 |
+| 10 | Advisory mode | ✅ | `SKILL.md` mode 1 + Advise example |
+| 11 | Pipeline design/generation mode | ✅ | `SKILL.md` mode 2 + two Generate examples |
+| 12 | Pipeline/repository review mode | ✅ | `SKILL.md` mode 3 + Review example |
+| 13 | Post-deployment DAST / runtime-dependent validation | ✅ | `DSB-SCAN-009`, `DSB-DEPLOY-004`, examples |
+| 14 | Custom/proprietary organizational tooling support | ✅ | Capability-based rules; catalog + applicability docs |
+| 15 | DSB-branded explanations and rule references | ✅ | "Voice and teaching" section; rule IDs cited throughout examples |
+| 16 | Correlate rules/recommendations with DSB curriculum | ✅ (initial) | Curriculum pointers required in output; direct module links pending (§14) |
+| 17 | Representative examples across organizational stacks | ✅ | Jenkins/Java/OpenShift, GitHub Actions/Node/EKS, GitLab/Terraform |
+| 18 | Compliant, non-compliant, and Not Applicable examples | ✅ | Review example (all three) + N/A sections in Generate examples |
+
+---
+
+## 12. Acceptance Criteria Traceability
+
+| Acceptance criterion | Met by |
+|---|---|
+| Dedicated DSB-owned repo under `devsecblueprint` exists | ⏳ Scaffold complete; push is the remaining step |
+| Repo contains skill, rule catalog, mappings, examples, contributor docs, attribution | §2, §11 |
+| Skill operates without repository access | Stated in `SKILL.md`; all modes work from supplied context |
+| Advises from high-level architecture/requirements | Advise mode + example |
+| Designs a pipeline from organizational requirements | Design/Generate mode with context checklist |
+| Generates implementation-ready CI/CD config with sufficient context | Generate examples (GitHub Actions, GitLab CI) |
+| Reviews an existing pipeline or repository | Review mode + example |
+| Consistently applies Build → Test → Scan → Deploy | Methodology in `SKILL.md`; principle 1; phase mapping required in all outputs |
+| Security scanning considered in every delivery design | `DSB-SCAN-001` (always applicable, BLOCK) |
+| Scanners selected on actual workload applicability | Selection algorithm; applicability tests |
+| SAST, SCA, secrets, IaC, container, pipeline, policy/config, DAST, API testing incorporated when appropriate | `DSB-SCAN-002..009` + capability catalog |
+| Post-deployment DAST/runtime requirements recognized | `DSB-SCAN-009`, `DSB-DEPLOY-004`; production-authorization guard |
+| Existing organizational tooling reused where appropriate | `prefer_existing_tool`; applicability step 3; Advise example |
+| Unnecessary/duplicate tooling avoided | `DSB-SCAN-010`; no-bloat rules |
+| Not Applicable controls explicitly identified | `DSB-EVD-003`; N/A sections in every example |
+| Custom/proprietary products supported without changing DSB rules | Capability-based rule design |
+| Ownership boundaries identified and respected | "Satisfied (externally owned)" pattern |
+| Explicit enforcement recommendations provided | Per-rule defaults + enforcement model |
+| DSB rules map to recognized industry guidance | §9 |
+| Engineering decisions explained, not just pipeline code | Mandatory rationale per rule; teaching requirement in `SKILL.md` |
+| Consistent with DSB curriculum and walkthroughs | Curriculum-first change policy (`CONTRIBUTING.md`); skill defers to curriculum as source |
+
+---
+
+## 13. Verification
+
+- `scripts/validate_rules.py` — **OK**: 42 rules across 11 families validated (required schema fields, family ID prefixes, ID uniqueness, allowed phases, enforcement levels, framework keys, tooling flags)
+- `.github/workflows/validate.yml` — CI runs the same validation plus secret scanning (`DSB-SCAN-004`) and pipeline-config scanning (`DSB-SCAN-008`) on every push/PR; the repository practices the methodology it teaches
+- Packaged as `dsb-devsecops-engineering.skill` for direct installation
+
+---
+
+## 14. Remaining Actions
+
+1. Open a PR against `devsecblueprint/devsecops-claude-skill` applying the v0.1.0 changes: MIT license swap (replace `LICENSE.md` PolyForm text, remove/rewrite `docs/legal/COMMERCIAL-LICENSING.md`, update `MAINTAINERS.md` and README licensing references), `commands/` + plugin manifest, README rewrite
+2. Re-run the repo's own validation and behavioral tests (`tools/validate_skill.py`, `pytest`) after the changes
+3. Tag and publish the v0.1.0 release
+4. Add direct links from individual rules to the specific DSB curriculum modules they correlate with
+5. Optional pre-announcement hardening: run evaluation prompts against each operating mode and iterate
+
+---
+
+*Owned and maintained by The DevSec Blueprint. This skill is an implementation of DSB knowledge and standards, not the source of those standards.*


### PR DESCRIPTION
## What this is

Implements the scaffold described in `docs/DevSec Blueprint — DevSecOps Engineering Skill.md`: a Claude Skill that advises on, designs, and reviews DevSecOps delivery pipelines using the DSB **Build → Test → Scan → Deploy** methodology.

It is capability-based, never vendor-based. DSB defines the required capabilities and engineering outcomes; the organization decides how to implement them. It is deliberately **not** a generic pipeline generator — it profiles the workload and reports what that workload actually needs, including what it does not.

## Contents

| Area | What landed |
|---|---|
| `SKILL.md` | Four phases, three operating modes (Advise / Design / Review), 20 baseline engineering principles, workload context checklist, control selection algorithm, output contract |
| `rules/` | **42 rules across 11 families**, each with the full schema: `applicability`, `framework_mappings`, `enforcement`, `tooling` |
| `commands/` | `/devsecops-engineer:advise`, `:design`, `:assess` — thin wrappers over the skill, plus the v0.1.0 plugin manifest |
| `references/` | Applicability flow, capability catalog, enforcement model, and NIST SSDF / SLSA / OWASP CI/CD / OWASP SAMM / CNCF mappings |
| `examples/` | Worked Advise (Jenkins/Java/OpenShift), two Generate (GitHub Actions/Node/EKS, GitLab CI/Terraform), and Review (Jenkinsfile) outputs |
| `scripts/` | `validate_rules.py` — schema, family prefix, ID uniqueness, phase, enforcement level, framework key, tooling flag, and per-family count checks |

Family breakdown: BUILD 4 · TEST 3 · SCAN 10 · DEPLOY 4 · ID 3 · SRC 3 · SC 3 · ART 4 · IAC 3 · EVD 3 · EXC 2.

## The repository practices what it teaches

CI (`.github/workflows/validate.yml`) runs catalog validation plus secret scanning (`DSB-SCAN-004`) and workflow config scanning (`DSB-SCAN-008`), with every third-party action pinned to a commit SHA (`DSB-SC-002`) and least-privilege permissions (`DSB-ID-002`).

## Verification

- `validate_rules.py` → **OK — 42 rules across 11 families**
- All 12 YAML files and `plugin.json` parse; `SKILL.md` frontmatter valid
- **Zero invented rule IDs** — every `DSB-*-NNN` cited across all 20 markdown files resolves to a real catalog entry
- Zero broken relative links
- Every GitHub Action SHA resolved against the live GitHub API rather than written from memory

## Please review closely

1. **The 20 Baseline Principles and the 42 rule requirement texts were authored, not transcribed.** The source report supplies rule IDs, counts, and family scopes but not the requirement wording, and describes the principles as verbatim from an issue that was not available. Both should be checked against the original issue.
2. **A fifth `phase` value, `cross-cutting`,** was introduced for the governance families (`DSB-ID`, `DSB-SRC`, `DSB-EVD`, `DSB-EXC`) that do not sit inside one of the four delivery phases. Documented in the validator and `SKILL.md`. Happy to collapse these onto the four if that is preferred.
3. **Placement as a subfolder.** The report specifies a standalone repository independent of this application codebase; this PR adds it here as a subfolder per the author's decision. Extracting it later is straightforward.

## Also included

Restores the markdown structure of `docs/DevSec Blueprint — DevSecOps Engineering Skill.md`, whose headings and eight tables had been flattened into unformatted text. Content unchanged. Three internal inconsistencies were left as-is and flagged rather than silently edited: the repo name (`devsecops-claude-skill` vs `devsecops-engineering-skill`), the stale "pending push" statuses in §2/§11/§12 that §0 explicitly corrects, and the packaged filename in §0a vs §13.

## Licensing

MIT. DSB branding, trademarks, and curriculum remain outside the grant per `docs/legal/TRADEMARKS.md`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)