### PR TITLE
ci: expand dependabot coverage

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -1,9 +1,67 @@
-# Set update schedule for GitHub Actions
+# Configure Dependabot updates for project dependencies and
+# GitHub Actions every week
+
 version: 2
 updates:
+# Covers pyproject.toml and uv.lock
+  - package-ecosystem: "uv"
+    directory: "/"
+    schedule:
+      interval: "weekly"
+    open-pull-requests-limit: 10
+    labels:
+      - "dependencies"
 
+# Covers GitHub Actions dependencies under .github/workflows/
   - package-ecosystem: "github-actions"
     directory: "/"
     schedule:
-      # Check for updates to GitHub Actions every week
-      interval: "daily"
+      interval: "weekly"
+    open-pull-requests-limit: 5
+    labels:
+      - "dependencies"
+      - "github_actions"
+
+# Covers frontend/package.json and frontend/package-lock.json
+  - package-ecosystem: "npm"
+    directory: "/frontend"
+    schedule:
+      interval: "weekly"
+    open-pull-requests-limit: 10
+    labels:
+      - "dependencies"
+    groups:
+      aws-sdk:
+        patterns:
+          - "@aws-sdk/*"
+        update-types:
+          - "minor"
+          - "patch"
+      react-ecosystem:
+        patterns:
+          - "react"
+          - "react-dom"
+          - "@types/react"
+          - "@types/react-dom"
+        update-types:
+          - "minor"
+          - "patch"
+      three-js:
+        patterns:
+          - "three"
+          - "@react-three/*"
+          - "@types/three"
+        update-types:
+          - "minor"
+          - "patch"
+      markdown-tools:
+        patterns:
+          - "remark-*"
+          - "rehype-*"
+          - "unified"
+          - "unist-util-*"
+          - "marked"
+          - "gray-matter"
+        update-types:
+          - "minor"
+          - "patch"

--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -11,6 +11,7 @@ updates:
     open-pull-requests-limit: 10
     labels:
       - "dependencies"
+      - "python"
 
 # Covers GitHub Actions dependencies under .github/workflows/
   - package-ecosystem: "github-actions"
@@ -30,6 +31,7 @@ updates:
     open-pull-requests-limit: 10
     labels:
       - "dependencies"
+      - "frontend"
     groups:
       aws-sdk:
         patterns:


### PR DESCRIPTION
Issue #174

## Summary
Expand the Dependabot coverage for uv, npm, and GitHub Actions
  
## Why
The goal is to establish a maintainable dependency-update strategy that keeps DSB current without overwhelming maintainers with low-value automated pull requests.