### PR TITLE
ci: expand dependabot coverage

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -12,6 +12,15 @@ updates:
     labels:
       - "dependencies"
       - "python"
+    groups:
+      aws-python-sdk:
+        patterns:
+          - "boto3"
+          - "botocore"
+          - "s3transfer"
+        update-types:
+          - "minor"
+          - "patch"
 
 # Covers GitHub Actions dependencies under .github/workflows/
   - package-ecosystem: "github-actions"


### PR DESCRIPTION
A follow-up on Issue https://github.com/devsecblueprint/devsecblueprint/issues/174
and PR: https://github.com/devsecblueprint/devsecblueprint/pull/185

## Why
Dependabot encountered dependency resolution conflicts. Dependabot was expanded to monitor the repository’s uv dependencies, but the initial configuration exposed a compatibility issue among related AWS SDK packages.
The root Python project directly depends on:

- boto3
- botocore
- s3transfer

These packages have interdependent version constraints. For example, boto3==1.42.82 requires a compatible botocore version below 1.43.0 and an appropriate s3transfer version. However, Dependabot evaluated update candidates independently and generated incompatible combinations, such as keeping boto3==1.42.82 while proposing botocore==1.43.72 or s3transfer==0.19.2.

This caused the uv Dependabot update check to fail with the error
`dependency_file_not_resolvable`

<img width="1440" height="784" alt="Screenshot 2026-08-19 at 6 42 47 AM" src="https://github.com/user-attachments/assets/cc123e0b-4e09-41c1-9afe-e7d62040957c" />


## The Fix
Group interdependent packages together