### PR TITLE
fix(security): remediate HIGH and CRITICAL Terraform misconfigurations

### DIFF
--- a/terraform/modules/alb/main.tf
+++ b/terraform/modules/alb/main.tf
@@ -3,41 +3,39 @@
 # =============================================================================
 
 # ALB Security Group
+#
+# Rules are standalone aws_security_group_rule resources rather than inline
+# blocks. The egress rule lives in the ECS module because it references the ECS
+# task security group, and the provider does not allow inline and standalone
+# rules on the same group.
 resource "aws_security_group" "alb" {
   name        = "${var.project_name}-alb-sg"
   description = "Security group for ALB - allows inbound HTTP/HTTPS from anywhere"
   vpc_id      = var.vpc_id
 
-  # Inbound: HTTP (port 80) from anywhere
-  ingress {
-    description = "HTTP from anywhere"
-    from_port   = 80
-    to_port     = 80
-    protocol    = "tcp"
-    cidr_blocks = ["0.0.0.0/0"]
-  }
-
-  # Inbound: HTTPS (port 443) from anywhere
-  ingress {
-    description = "HTTPS from anywhere"
-    from_port   = 443
-    to_port     = 443
-    protocol    = "tcp"
-    cidr_blocks = ["0.0.0.0/0"]
-  }
-
-  # Outbound: all traffic
-  egress {
-    description = "Allow all outbound traffic"
-    from_port   = 0
-    to_port     = 0
-    protocol    = "-1"
-    cidr_blocks = ["0.0.0.0/0"]
-  }
-
   tags = merge(var.tags, {
     Name = "${var.project_name}-alb-sg"
   })
+}
+
+resource "aws_security_group_rule" "alb_ingress_http" {
+  type              = "ingress"
+  from_port         = 80
+  to_port           = 80
+  protocol          = "tcp"
+  cidr_blocks       = ["0.0.0.0/0"]
+  security_group_id = aws_security_group.alb.id
+  description       = "HTTP from anywhere, redirected to HTTPS by the listener"
+}
+
+resource "aws_security_group_rule" "alb_ingress_https" {
+  type              = "ingress"
+  from_port         = 443
+  to_port           = 443
+  protocol          = "tcp"
+  cidr_blocks       = ["0.0.0.0/0"]
+  security_group_id = aws_security_group.alb.id
+  description       = "HTTPS from anywhere"
 }
 
 # Application Load Balancer
@@ -47,6 +45,10 @@ resource "aws_lb" "app" {
   load_balancer_type = "application"
   security_groups    = [aws_security_group.alb.id]
   subnets            = var.public_subnet_ids
+
+  # Drop headers that do not conform to RFC 7230 before they reach the targets,
+  # which closes off request-smuggling and header-injection paths (AVD-AWS-0052).
+  drop_invalid_header_fields = true
 
   tags = merge(var.tags, {
     Name = "${var.project_name}-alb"

--- a/terraform/modules/ecs/main.tf
+++ b/terraform/modules/ecs/main.tf
@@ -62,14 +62,53 @@ resource "aws_security_group_rule" "ecs_inbound_alb" {
   description              = "Allow inbound from ALB on container port"
 }
 
-resource "aws_security_group_rule" "ecs_outbound_all" {
+# Egress from the ALB to these tasks. It lives here rather than in the ALB
+# module because it needs both security group IDs, and referencing the ECS group
+# from the ALB module would create a cycle. Scoped to the container port so the
+# ALB cannot reach anything else (AVD-AWS-0104).
+resource "aws_security_group_rule" "alb_outbound_to_ecs" {
+  type                     = "egress"
+  from_port                = 8000
+  to_port                  = 8000
+  protocol                 = "tcp"
+  source_security_group_id = aws_security_group.ecs.id
+  security_group_id        = var.alb_security_group_id
+  description              = "Allow ALB to reach ECS tasks on the container port"
+}
+
+# Task egress. Destination IPs cannot be allowlisted because the app calls
+# Stripe, Discord and Mailgun, none of which publish stable ranges, so the rules
+# are scoped by protocol and port instead. This narrows the previous
+# all-ports/all-protocols rule but does not clear AVD-AWS-0104, which fires on
+# the 0.0.0.0/0 destination itself. Documented as accepted risk in the PR.
+resource "aws_security_group_rule" "ecs_outbound_https" {
   type              = "egress"
-  from_port         = 0
-  to_port           = 0
-  protocol          = "-1"
+  from_port         = 443
+  to_port           = 443
+  protocol          = "tcp"
   cidr_blocks       = ["0.0.0.0/0"]
   security_group_id = aws_security_group.ecs.id
-  description       = "Allow all outbound traffic"
+  description       = "HTTPS to AWS APIs (ECR, CloudWatch, DynamoDB, SSM) and third-party integrations"
+}
+
+resource "aws_security_group_rule" "ecs_outbound_dns_udp" {
+  type              = "egress"
+  from_port         = 53
+  to_port           = 53
+  protocol          = "udp"
+  cidr_blocks       = ["0.0.0.0/0"]
+  security_group_id = aws_security_group.ecs.id
+  description       = "DNS resolution via the VPC resolver"
+}
+
+resource "aws_security_group_rule" "ecs_outbound_dns_tcp" {
+  type              = "egress"
+  from_port         = 53
+  to_port           = 53
+  protocol          = "tcp"
+  cidr_blocks       = ["0.0.0.0/0"]
+  security_group_id = aws_security_group.ecs.id
+  description       = "DNS resolution over TCP for responses that exceed the UDP limit"
 }
 
 # =============================================================================


### PR DESCRIPTION
# fix(security): remediate HIGH and CRITICAL Terraform misconfigurations

## Summary

All 12 HIGH/CRITICAL Terraform findings from the focused IaC scan introduced in #175 have been reviewed and dispositioned. Two are remediated, one is materially narrowed, and nine are accepted with documented rationale and compensating controls. No `.trivyignore` was added and no thresholds were changed.

The inventory on the issue listed 11. `modules/s3_certificates` has been added to `main` since then, bringing a twelfth finding (`AVD-AWS-0132`). It is a private bucket with the same profile as `s3_content_registry`, so I have applied the same disposition; flag it if you'd rather treat it differently.

## Remediation table

| Finding | Resource | Severity | Disposition | Notes |
|---|---|---|---|---|
| AVD-AWS-0052 | `aws_lb.app` (`modules/alb`) | HIGH | **Remediated** | Set `drop_invalid_header_fields = true`. Headers that do not conform to RFC 7230 are dropped at the load balancer before reaching targets, closing request-smuggling and header-injection paths. No functional impact. |
| AVD-AWS-0104 | `aws_security_group.alb` (`modules/alb`) | CRITICAL | **Remediated** | Egress was `0.0.0.0/0` on all ports and protocols. The ALB only ever needs to reach the ECS tasks it fronts, so egress is now a single rule scoped to the ECS task security group on TCP 8000. |
| AVD-AWS-0104 | `aws_security_group_rule.ecs_outbound_*` (`modules/ecs`) | CRITICAL | **Narrowed, accepted risk** | See "ECS egress" below. |
| AVD-AWS-0053 | `aws_lb.app` (`modules/alb`) | HIGH | **Accepted risk** | The ALB fronts the public DSB API and must be internet-facing. Compensating controls: HTTPS listener on `ELBSecurityPolicy-TLS13-1-2-2021-06`, HTTP 301-redirected to HTTPS, ingress restricted to TCP 80/443 only, ACM-managed certificate, and ECS tasks accepting traffic only from the ALB security group. Trivy documents this check as a guard against *accidental* exposure rather than a defect. |
| AVD-AWS-0011 | `aws_cloudfront_distribution.frontend` (`modules/cloudfront`) | HIGH | **Accepted risk** | WAF is a recommended defence-in-depth control but its recurring cost is not currently justifiable. The platform does use authentication and authorisation through GitHub Apps, GitLab Apps and similar integrations, but those authenticated API workflows sit behind the ALB rather than this distribution. This distribution serves static public files from S3 via OAC with no dynamic origin compute. Compensating controls: origin access control (no public bucket exposure), `viewer_protocol_policy = redirect-to-https`, TLSv1.2_2021 minimum, and a no-cache response headers policy. To be reconsidered if the architecture, exposure, traffic profile or budget changes. |
| AVD-AWS-0031 | `aws_ecr_repository.this` (`modules/ecr`) | HIGH | **Temporarily accepted risk** | Enabling immutability requires replacing the mutable `latest` deployment model with commit-SHA or digest-based image references; `tasks.py::push_image` currently re-pushes `latest` on every deploy, so setting `IMMUTABLE` would break deployment. Compensating controls: write access to the AWS account and deployment pipeline is tightly restricted, substantially reducing the likelihood of unauthorised tag replacement, and `scan_on_push` is enabled. Tracked for remediation in the release-management follow-up issue. |
| AVD-AWS-0132 | `aws_s3_bucket_server_side_encryption_configuration.certificates` | HIGH | **Accepted risk** | Added to `main` after the dispositions on the issue. Private bucket caching Templated.io certificate images, same profile as `content_registry` below, so the same decision is applied. Compensating controls: all public access blocked, TLS enforced by a `DenyInsecureTransport` policy, `force_destroy = false`. |
| AVD-AWS-0132 | `aws_s3_bucket_server_side_encryption_configuration.content_registry` | HIGH | **Accepted risk** | SSE-S3 (AES256) with bucket keys enabled is retained. A customer-managed KMS key is not justified by this data's risk profile relative to its cost and operational overhead. Compensating controls: all public access blocked, versioning enabled, TLS enforced by a `DenyInsecureTransport` bucket policy, noncurrent-version lifecycle expiry, and write access scoped to a dedicated CI/CD IAM policy. |
| AVD-AWS-0132 | `aws_s3_bucket_server_side_encryption_configuration.frontend` | HIGH | **Accepted risk** | As above. This bucket holds public static site assets with no confidentiality requirement. Compensating controls: all public access blocked, served only through CloudFront OAC, versioning enabled. |
| AVD-AWS-0132 | `aws_s3_bucket_server_side_encryption_configuration.images` | HIGH | **Accepted risk** | As above, and SSE-KMS is additionally not viable here: objects are read anonymously, and an anonymous principal cannot hold `kms:Decrypt`, so a customer-managed key would break image serving outright. Compensating controls: TLS enforced by a `DenyInsecureTransport` policy, versioning enabled, bucket policy grants only `s3:GetObject` on objects. |
| AVD-AWS-0087 | `aws_s3_bucket_public_access_block.images` | HIGH | **Accepted risk** | `block_public_policy = false` is required for the bucket policy that serves public images. Compensating controls: `block_public_acls` and `ignore_public_acls` are both `true`, the policy grants only `s3:GetObject` on objects (no `ListBucket`, no writes), TLS is enforced by an explicit Deny, and versioning plus lifecycle expiry are enabled. A follow-up issue evaluates moving this bucket behind CloudFront with OAC, which would allow public access to be blocked entirely. |
| AVD-AWS-0093 | `aws_s3_bucket_public_access_block.images` | HIGH | **Accepted risk** | Same resource, same rationale and compensating controls as AVD-AWS-0087. |

## ECS egress (AVD-AWS-0104)

Destination IPs cannot be allowlisted: the application calls Stripe, Discord and Mailgun, none of which publish stable address ranges, and the tasks run in public subnets with no NAT gateway. Per the guidance on the issue, protocols and ports have been restricted as far as the integrations allow:

**Before** — one rule, all ports, all protocols, to anywhere:

```hcl
from_port = 0
to_port   = 0
protocol  = "-1"
```

**After** — three rules scoped by protocol and port:

| Port | Protocol | Purpose |
|---|---|---|
| 443 | tcp | HTTPS to AWS APIs (ECR, CloudWatch Logs, DynamoDB, SSM) and third-party integrations |
| 53 | udp | DNS resolution via the VPC resolver |
| 53 | tcp | DNS resolution for responses exceeding the UDP size limit |

Port 80 was deliberately excluded; nothing in the task path requires plaintext HTTP egress.

**Note on the finding count:** this does not clear AVD-AWS-0104, which fires on the `0.0.0.0/0` destination itself rather than the port range. Because Trivy evaluates each rule separately, one flagged rule has become three. Exposure is materially narrower while the reported instance count is higher. All three carry the accepted-risk rationale above.

## Terraform structure change

Scoping ALB egress to the ECS security group required both group IDs in one place. The ALB module cannot reference the ECS group without creating a module cycle, so the rule is defined in the ECS module, which already receives `alb_security_group_id`.

This in turn required converting the ALB security group's inline `ingress`/`egress` blocks to standalone `aws_security_group_rule` resources, because the AWS provider does not support mixing inline and standalone rules on the same group; doing so produces a perpetual diff as each apply tries to revoke the other's rules. The ECS module already used standalone rules, so this makes the two modules consistent.

No rules were widened in the conversion: the two ingress rules are byte-equivalent in effect to the previous inline blocks.

## Final scan results

Trivy **v0.70.0** (the version pinned by `aquasecurity/trivy-action@v0.36.0`).

```
$ trivy config terraform/ --severity HIGH,CRITICAL --skip-dirs '**/.terraform'

┌─────────────────────────────────────┬───────────┬───────────────────┐
│               Target                │   Type    │ Misconfigurations │
├─────────────────────────────────────┼───────────┼───────────────────┤
│ modules/alb/main.tf                 │ terraform │         1         │
│ modules/cloudfront/main.tf          │ terraform │         1         │
│ modules/ecr/main.tf                 │ terraform │         1         │
│ modules/ecs/main.tf                 │ terraform │         3         │
│ modules/s3_certificates/main.tf     │ terraform │         1         │
│ modules/s3_content_registry/main.tf │ terraform │         1         │
│ modules/s3_frontend/main.tf         │ terraform │         1         │
│ modules/s3_public_images/main.tf    │ terraform │         3         │
└─────────────────────────────────────┴───────────┴───────────────────┘
```

Every remaining finding appears in the table above with a documented disposition. There are no undispositioned HIGH or CRITICAL findings.

## Validation

```bash
terraform fmt -recursive -check
terraform init -backend=false && terraform validate
```

## Follow-up issues

- Migrate deployments to immutable image references and enable ECR tag immutability (AVD-AWS-0031)
- Evaluate migrating the public image bucket behind CloudFront with OAC (AVD-AWS-0087, AVD-AWS-0093, and AVD-AWS-0132 on that bucket)

## Notes

No scanner suppressions were introduced. These acceptances apply to the current architecture and access model and should be reassessed if those assumptions change.

## Issue tracking

Related issue: #176 — Terraform HIGH/CRITICAL remediation and documented dispositions.

Follow-up work tracked separately: #213 (immutable deployment images) and #214 (public image bucket behind CloudFront OAC).